### PR TITLE
Stop specifying version of php-gmp extension.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Phillip Shipley <phillip.shipley@gmail.com>
 ENV REFRESHED_AT 2016-12-16
 
 RUN apt-get update -y && \
-    apt-get install -y php-memcache php7.0-gmp && \
+    apt-get install -y php-memcache php-gmp && \
     apt-get clean
 
 # Create required directories


### PR DESCRIPTION
This is to match the similar change made in the php7 docker image.