### PR TITLE
Use IDP_DISPLAY_NAME if available.

### DIFF
--- a/dockerbuild/ssp-overrides/config.php
+++ b/dockerbuild/ssp-overrides/config.php
@@ -17,6 +17,7 @@ try {
     $ADMIN_PASS = Env::requireEnv('ADMIN_PASS');
     $SECRET_SALT = Env::requireEnv('SECRET_SALT');
     $IDP_NAME = Env::requireEnv('IDP_NAME');
+    $IDP_DISPLAY_NAME = Env::get('IDP_DISPLAY_NAME', $IDP_NAME);
 } catch (EnvVarNotFoundException $e) {
 
     // Log to syslog (Logentries).
@@ -70,9 +71,14 @@ $config = [
      'hubmode' => $HUB_MODE,
 
      /*
-      * Name of this IdP to display to the user
+      * Name of this IdP
       */
      'idp_name' => $IDP_NAME,
+
+     /*
+      * Name of this IdP to display to the user
+      */
+     'idp_display_name' => $IDP_DISPLAY_NAME,
 
      /*
       * The tracking Id for Google Analytics or some other similar service


### PR DESCRIPTION
This makes the IdP's display name available in the config, which will allow us to use it from the material theme.

Since the material theme is just a theme (which others could use), I don't know if we should have the material theme conditionally look for idp_display_name in the config (and if not present, use the idp_name config instead) or if it can simply expect an idp_display_name to be present.