### PR TITLE
Get updated psr3-adapters.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1739,16 +1739,16 @@
         },
         {
             "name": "silinternational/psr3-adapters",
-            "version": "1.1.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silinternational/psr3-adapters.git",
-                "reference": "bbaef684f34f94f64dcf018698028b786f67caaa"
+                "reference": "e095250f68267d749e67d3e9d8e02980a83a1042"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silinternational/psr3-adapters/zipball/bbaef684f34f94f64dcf018698028b786f67caaa",
-                "reference": "bbaef684f34f94f64dcf018698028b786f67caaa",
+                "url": "https://api.github.com/repos/silinternational/psr3-adapters/zipball/e095250f68267d749e67d3e9d8e02980a83a1042",
+                "reference": "e095250f68267d749e67d3e9d8e02980a83a1042",
                 "shasum": ""
             },
             "require": {
@@ -1761,7 +1761,7 @@
             },
             "suggest": {
                 "monolog/monolog": "^1.22",
-                "simplesamlphp/simplesamlphp": "^1.14.12",
+                "simplesamlphp/simplesamlphp": "^1.15.2",
                 "yiisoft/yii2": "^2.0"
             },
             "type": "library",
@@ -1782,7 +1782,7 @@
                 }
             ],
             "description": "Various PSR3-compatible logging adapters.",
-            "time": "2017-05-09T19:14:19+00:00"
+            "time": "2018-02-06T14:25:02+00:00"
         },
         {
             "name": "silinternational/simplesamlphp-module-expirychecker",
@@ -1867,16 +1867,16 @@
         },
         {
             "name": "silinternational/simplesamlphp-module-mfa",
-            "version": "2.0.4",
+            "version": "2.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silinternational/simplesamlphp-module-mfa.git",
-                "reference": "ee166006de0946d4277aca4b568096eb2b7ea58a"
+                "reference": "d8f8efcec3057e7c2918ecac6e8a748707a48f1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silinternational/simplesamlphp-module-mfa/zipball/ee166006de0946d4277aca4b568096eb2b7ea58a",
-                "reference": "ee166006de0946d4277aca4b568096eb2b7ea58a",
+                "url": "https://api.github.com/repos/silinternational/simplesamlphp-module-mfa/zipball/d8f8efcec3057e7c2918ecac6e8a748707a48f1f",
+                "reference": "d8f8efcec3057e7c2918ecac6e8a748707a48f1f",
                 "shasum": ""
             },
             "require": {
@@ -1884,7 +1884,7 @@
                 "roave/security-advisories": "dev-master",
                 "silinternational/idp-id-broker-php-client": "^2.2",
                 "silinternational/php-env": "^2.1",
-                "silinternational/psr3-adapters": "^1.1",
+                "silinternational/psr3-adapters": "^1.1 || ^2.0",
                 "simplesamlphp/simplesamlphp": "~1.15.2"
             },
             "require-dev": {
@@ -1911,20 +1911,20 @@
                 }
             ],
             "description": "A simpleSAMLphp module for prompting the user for MFA credentials (such as a TOTP code, etc.).",
-            "time": "2018-02-07T16:29:31+00:00"
+            "time": "2018-02-08T19:43:13+00:00"
         },
         {
             "name": "silinternational/simplesamlphp-module-silauth",
-            "version": "4.0.3",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silinternational/simplesamlphp-module-silauth.git",
-                "reference": "387604d0bf9ccf26bfdfb34efc44a544d797baed"
+                "reference": "877dc62d60dc8d879109fef47d6ef22d1eed66ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silinternational/simplesamlphp-module-silauth/zipball/387604d0bf9ccf26bfdfb34efc44a544d797baed",
-                "reference": "387604d0bf9ccf26bfdfb34efc44a544d797baed",
+                "url": "https://api.github.com/repos/silinternational/simplesamlphp-module-silauth/zipball/877dc62d60dc8d879109fef47d6ef22d1eed66ec",
+                "reference": "877dc62d60dc8d879109fef47d6ef22d1eed66ec",
                 "shasum": ""
             },
             "require": {
@@ -1939,7 +1939,7 @@
                 "roave/security-advisories": "dev-master",
                 "silinternational/idp-id-broker-php-client": "^2.0",
                 "silinternational/php-env": "^2.0",
-                "silinternational/psr3-adapters": "^1.1",
+                "silinternational/psr3-adapters": "^1.1 || ^2.0",
                 "simplesamlphp/simplesamlphp": "^1.14.17",
                 "yiisoft/yii2": "~2.0.12",
                 "yiisoft/yii2-gii": "^2.0"
@@ -1966,7 +1966,7 @@
                 }
             ],
             "description": "SimpleSAMLphp auth module implementing various security measures before calls to IdP ID Broker backend",
-            "time": "2018-02-07T16:11:50+00:00"
+            "time": "2018-02-08T19:52:04+00:00"
         },
         {
             "name": "silinternational/simplesamlphp-module-sildisco",


### PR DESCRIPTION
This should reduce the warnings in our logs about SimpleSAML_Logger
having been namespaced to SimpleSAML\Logger.