### PR TITLE
Show O/S and PHP version info in logs

### DIFF
--- a/dockerbuild/run.sh
+++ b/dockerbuild/run.sh
@@ -11,7 +11,8 @@ trap 'kill ${!}; term_handler' SIGTERM
 cd /data
 ./setup-logentries.sh
 
-# Send info about this image's PHP and O/S version to our logs.
+# Send info about this image's O/S and PHP version to our logs.
+cat /etc/*release | grep PRETTY | logger -p 1 -t run.warning
 php -v | head -n 1 | logger -p 1 -t run.warning
 
 apache2ctl start

--- a/dockerbuild/run.sh
+++ b/dockerbuild/run.sh
@@ -11,6 +11,9 @@ trap 'kill ${!}; term_handler' SIGTERM
 cd /data
 ./setup-logentries.sh
 
+# Send info about this image's PHP and O/S version to our logs.
+php -v | head -n 1 | logger -p 1 -t run.warning
+
 apache2ctl start
 
 # endless loop with a wait is needed for the trap to work


### PR DESCRIPTION
This is to have containers (when first starting up, not on each request) output to the logs what O/S version and what PHP version is running.

**Example output:**  
```
PRETTY_NAME="Ubuntu 18.04.3 LTS"
PHP 7.2.19-0ubuntu0.18.04.2 (cli) (built: Aug 12 2019 19:34:28) ( NTS )
```