### PR TITLE
Stop tracking builds as deployments

### DIFF
--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -89,8 +89,3 @@ ssp-hub-sp.local:
     SHOW_SAML_ERRORS: "true"
     SAML20_IDP_ENABLE: "false"
     ADMIN_PROTECT_INDEX_PAGE: "false"
-
-tracker:
-  image: silintl/app-deployment-tracker-ga:latest
-  environment:
-    TRACKING_ID: UA-56269387-10

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -19,8 +19,3 @@
   tag: master
   registry: https://index.docker.io/v1/
   encrypted_dockercfg_path: dockercfg.encrypted
-
-- name: track_deployment
-  service: tracker
-  tag: ^(main|master|develop)
-  command: "true"


### PR DESCRIPTION
### Fixed
- Remove CI/CD step to track deployments, since this doesn't directly deploy anywhere