### PR TITLE
Release 9.2.5 -- fix image name in Docker publish action

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -38,7 +38,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: "$IMAGE_NAME"
+          images: ${{ env.IMAGE_NAME }}
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -38,7 +38,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: $IMAGE_NAME
+          images: "$IMAGE_NAME"
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -3,6 +3,9 @@ name: Test and Publish
 on:
   push:
 
+env:
+  IMAGE_NAME: ${{ vars.DOCKER_ORG }}/ssp-base
+
 jobs:
   tests:
     name: Tests
@@ -35,7 +38,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ vars.DOCKER_ORG }}/idp-id-broker
+          images: $IMAGE_NAME
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
### Fixed
- Fixed copy-paste error

### Changed
- Move the Docker publish image name into a variable so it's more prominent