### PR TITLE
IDP-892 - enable modules using module.enable in config.php

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,11 +36,7 @@ WORKDIR /data
 # Install/cleanup composer dependencies
 COPY composer.json /data/
 COPY composer.lock /data/
-# TODO/FIXME: Disabled the self-update due to a breaking change between composer 2.6.6 and 2.7.1 that affects the
-# loading of the simplesamlphp/simplesamlphp/modules folder. The Docker build fails on the sildisco/sspoverrides line.
-# It is not well understood what changed in composer, but since the overrides will need to be redesigned during
-# the SimpleSAMLphp 2.x upgrade, this issue is deferred until then.
-#RUN composer self-update --no-interaction
+RUN composer self-update --no-interaction
 RUN COMPOSER_ALLOW_SUPERUSER=1 composer install --prefer-dist --no-interaction --no-dev --optimize-autoloader --no-scripts --no-progress
 
 # Copy in SSP override files

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update -y \
         php-gmp \
         php-memcached \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*    
+    && rm -rf /var/lib/apt/lists/*
 
 # Create required directories
 RUN mkdir -p /data
@@ -41,7 +41,7 @@ COPY composer.lock /data/
 # It is not well understood what changed in composer, but since the overrides will need to be redesigned during
 # the SimpleSAMLphp 2.x upgrade, this issue is deferred until then.
 #RUN composer self-update --no-interaction
-RUN composer install --prefer-dist --no-interaction --no-dev --optimize-autoloader --no-scripts --no-progress
+RUN COMPOSER_ALLOW_SUPERUSER=1 composer install --prefer-dist --no-interaction --no-dev --optimize-autoloader --no-scripts --no-progress
 
 # Copy in SSP override files
 ENV SSP_PATH /data/vendor/simplesamlphp/simplesamlphp

--- a/development/idp-local/config/config.php
+++ b/development/idp-local/config/config.php
@@ -595,6 +595,12 @@ $config = [
     'module.enable' => [
         // Setting to TRUE enables.
         'authgoogle' => $GOOGLE_ENABLE,
+        'expirychecker' => true,
+        'material' => true,
+        'mfa' => true,
+        'profilereview' => true,
+        'silauth' => true,
+        'sildisco' => true,
     ],
 
 

--- a/development/idp2-local/config/config.php
+++ b/development/idp2-local/config/config.php
@@ -327,6 +327,12 @@ $config = [
     'module.enable' => [
         // Setting to TRUE enables.
         'authgoogle' => $GOOGLE_ENABLE,
+        'expirychecker' => true,
+        'material' => true,
+        'mfa' => true,
+        'profilereview' => true,
+        'silauth' => true,
+        'sildisco' => true,
     ],
 
     /*

--- a/development/sp-local/config/config.php
+++ b/development/sp-local/config/config.php
@@ -297,6 +297,12 @@ $config = [
     'module.enable' => [
         // Setting to TRUE enables.
         'authgoogle' => $GOOGLE_ENABLE,
+        'expirychecker' => true,
+        'material' => true,
+        'mfa' => true,
+        'profilereview' => true,
+        'silauth' => true,
+        'sildisco' => true,
     ],
 
     /*

--- a/development/sp2-local/config/config.php
+++ b/development/sp2-local/config/config.php
@@ -297,6 +297,12 @@ $config = [
     'module.enable' => [
         // Setting to TRUE enables.
         'authgoogle' => $GOOGLE_ENABLE,
+        'expirychecker' => true,
+        'material' => true,
+        'mfa' => true,
+        'profilereview' => true,
+        'silauth' => true,
+        'sildisco' => true,
     ],
 
     /*

--- a/dockerbuild/ssp-overrides/config.php
+++ b/dockerbuild/ssp-overrides/config.php
@@ -595,6 +595,12 @@ $config = [
     'module.enable' => [
         // Setting to TRUE enables.
         'authgoogle' => $GOOGLE_ENABLE,
+        'expirychecker' => true,
+        'material' => true,
+        'mfa' => true,
+        'profilereview' => true,
+        'silauth' => true,
+        'sildisco' => true,
     ],
 
 


### PR DESCRIPTION
### Added
- Added all required modules to the `module.enable` section of the config.php file. ([IDP-892](https://itse.youtrack.cloud/issue/IDP-892))