### PR TITLE
directly include expirychecker module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ ENV SSP_PATH /data/vendor/simplesamlphp/simplesamlphp
 
 # Copy modules into simplesamlphp
 COPY modules/ $SSP_PATH/modules
+COPY behat.yml .
 
 # Copy in SSP override files
 RUN mv $SSP_PATH/www/index.php $SSP_PATH/www/ssp-index.php

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,6 @@ ENV SSP_PATH /data/vendor/simplesamlphp/simplesamlphp
 
 # Copy modules into simplesamlphp
 COPY modules/ $SSP_PATH/modules
-COPY behat.yml .
 
 # Copy in SSP override files
 RUN mv $SSP_PATH/www/index.php $SSP_PATH/www/ssp-index.php

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,12 @@ COPY composer.lock /data/
 RUN composer self-update --no-interaction
 RUN COMPOSER_ALLOW_SUPERUSER=1 composer install --prefer-dist --no-interaction --no-dev --optimize-autoloader --no-scripts --no-progress
 
-# Copy in SSP override files
 ENV SSP_PATH /data/vendor/simplesamlphp/simplesamlphp
+
+# Copy modules into simplesamlphp
+COPY modules/ $SSP_PATH/modules
+
+# Copy in SSP override files
 RUN mv $SSP_PATH/www/index.php $SSP_PATH/www/ssp-index.php
 COPY dockerbuild/ssp-overrides/index.php $SSP_PATH/www/index.php
 RUN mv $SSP_PATH/www/saml2/idp/SingleLogoutService.php $SSP_PATH/www/saml2/idp/ssp-SingleLogoutService.php

--- a/README.md
+++ b/README.md
@@ -97,3 +97,77 @@ RUN cd /data/vendor/simplesamlphp/simplesamlphp/modules/material/dictionaries/ov
 ## Misc. Notes
 
 * Use of sildisco's LogUser module is optional and triggered via an authproc.
+
+## Included Modules
+
+### ExpiryChecker simpleSAMLphp Module
+A simpleSAMLphp module for warning users that their password will expire soon
+or that it has already expired.
+
+**NOTE:** This module does *not* prevent the user from logging in. It merely
+shows a warning page (if their password is about to expire), with the option to
+change their password now or later, or it tells the user that their password has
+already expired, with the only option being to go change their password now.
+Both of these pages will be bypassed (for varying lengths of time) if the user
+has recently seen one of those two pages, in order to allow the user to get to
+the change-password website (assuming it is also behind this IdP). If the user
+should not be allowed to log in at all, the simpleSAMLphp Auth. Source should
+consider the credentials provided by the user to be invalid.
+
+The expirychecker module is implemented as an Authentication Processing Filter,
+or AuthProc. That means it can be configured in the global config.php file or
+the SP remote or IdP hosted metadata.
+
+It is recommended to run the expirychecker module at the IdP, and configure the
+filter to run before all the other filters you may have enabled.
+
+#### How to use the module
+
+Set filter parameters in your config. We recommend adding
+them to the `'authproc'` array in your `metadata/saml20-idp-hosted.php` file,
+but you are also able to put them in the `'authproc.idp'` array in your
+`config/config.php` file.
+
+Example (in `metadata/saml20-idp-hosted.php`):
+
+    'authproc' => [
+        10 => [
+            // Required:
+            'class' => 'expirychecker:ExpiryDate',
+            'accountNameAttr' => 'cn',
+            'expiryDateAttr' => 'schacExpiryDate',
+            'passwordChangeUrl' => 'https://idm.example.com/pwdmgr/',
+
+            // Optional:
+            'warnDaysBefore' => 14,
+            'originalUrlParam' => 'originalurl',
+            'dateFormat' => 'm.d.Y', // Use PHP's date syntax.
+            'loggerClass' => '\\Sil\\Psr3Adapters\\Psr3SamlLogger',
+        ],
+        
+        // ...
+    ],
+
+The `accountNameAttr` parameter represents the SAML attribute name which has
+the user's account name stored in it. In certain situations, this will be
+displayed to the user, as well as being used in log messages.
+
+The `expiryDateAttr` parameter represents the SAML attribute name which has
+the user's expiry date, which must be formated as YYYYMMDDHHMMSSZ (e.g.
+`20111011235959Z`). Those two attributes need to be part of the attribute set
+returned when the user successfully authenticates.
+
+The `warnDaysBefore` parameter should be an integer representing how many days
+before the expiry date the "about to expire" warning will be shown to the user.
+
+The `dateFormat` parameter specifies how you want the date to be formatted,
+using PHP `date()` syntax. See <http://php.net/manual/en/function.date.php>.
+
+The `loggerClass` parameter specifies the name of a PSR-3 compatible class that
+can be autoloaded, to use as the logger within ExpiryDate.
+
+#### Acknowledgements
+
+This is adapted from the `ssp-iidp-expirycheck` and `expirycheck` modules.
+Thanks to Alex Mihičinac, Steve Moitozo, and Steve Bagwell for the initial work
+they did on those two modules.

--- a/actions-services.yml
+++ b/actions-services.yml
@@ -12,6 +12,7 @@ services:
       - ./dockerbuild/run-metadata-tests.sh:/data/run-metadata-tests.sh
       - ./dockerbuild/run-tests.sh:/data/run-tests.sh
       - ./features:/data/features
+      - ./behat.yml:/data/behat.yml
       - ./tests:/data/tests
 
   test-browser:

--- a/behat.yml
+++ b/behat.yml
@@ -1,0 +1,17 @@
+default:
+  suites:
+    dictionary_features:
+      paths:    [ '%paths.base%//features//dictionary-overrides.feature' ]
+      contexts: [ 'FeatureContext' ]
+    expiry_features:
+      paths:    [ '%paths.base%//features//expirychecker.feature' ]
+      contexts: [ 'ExpiryContext' ]
+    material_features:
+      paths:    [ '%paths.base%//features//material.feature' ]
+      contexts: [ 'FeatureContext' ]
+    mfa_features:
+      paths:    [ '%paths.base%//features//mfa.feature' ]
+      contexts: [ 'FeatureContext' ]
+    profilereview_features:
+      paths:    [ '%paths.base%//features//profilereview.feature' ]
+      contexts: [ 'FeatureContext' ]

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     "ext-memcached": "*",
     "simplesamlphp/simplesamlphp": "^1.19.6",
     "simplesamlphp/composer-module-installer": "1.1.8",
-    "silinternational/simplesamlphp-module-expirychecker": "^3.1.0",
     "silinternational/simplesamlphp-module-silauth": "^7.1.1",
     "silinternational/simplesamlphp-module-mfa": "^5.2.1",
     "silinternational/simplesamlphp-module-profilereview": "^2.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "df01bb039aaf6b25519b9e6dea6dae58",
+    "content-hash": "aa7c6c86f5fefed69d818d69b1a506c3",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -2941,57 +2941,6 @@
                 "source": "https://github.com/silinternational/psr3-adapters/tree/3.1.0"
             },
             "time": "2022-08-24T14:44:38+00:00"
-        },
-        {
-            "name": "silinternational/simplesamlphp-module-expirychecker",
-            "version": "3.1.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/silinternational/simplesamlphp-module-expirychecker.git",
-                "reference": "2a8f8b18fe60ba3e0e3d7e9c039bcf7347bddb29"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/silinternational/simplesamlphp-module-expirychecker/zipball/2a8f8b18fe60ba3e0e3d7e9c039bcf7347bddb29",
-                "reference": "2a8f8b18fe60ba3e0e3d7e9c039bcf7347bddb29",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "php": ">=7.2",
-                "silinternational/psr3-adapters": "^1.1 || ^2.0 || ^3.0",
-                "simplesamlphp/simplesamlphp": "~1.17.7 || ~1.18.4 || ~1.19.0"
-            },
-            "require-dev": {
-                "behat/behat": "^3.3",
-                "behat/mink": "^1.7",
-                "behat/mink-goutte-driver": "^1.2",
-                "phpunit/phpunit": "^8.4",
-                "roave/security-advisories": "dev-master"
-            },
-            "type": "simplesamlphp-module",
-            "autoload": {
-                "psr-4": {
-                    "Sil\\SspExpiryChecker\\": "src/",
-                    "Sil\\SspExpiryChecker\\Behat\\": "features/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL-2.1"
-            ],
-            "authors": [
-                {
-                    "name": "Matt Henderson",
-                    "email": "matt_henderson@sil.org"
-                }
-            ],
-            "description": "simpleSAMLphp module for warning users that their password will expire soon or has already expired.",
-            "support": {
-                "issues": "https://github.com/silinternational/simplesamlphp-module-expirychecker/issues",
-                "source": "https://github.com/silinternational/simplesamlphp-module-expirychecker/tree/3.1.3"
-            },
-            "time": "2023-02-08T15:53:15+00:00"
         },
         {
             "name": "silinternational/simplesamlphp-module-material",
@@ -10036,5 +9985,5 @@
         "ext-memcached": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/development/idp-local/config/authsources.php
+++ b/development/idp-local/config/authsources.php
@@ -24,7 +24,7 @@ $config = [
                 gmdate('YmdHis\Z', strtotime('+6 months')), // Distant future
             ],
         ],
-        'near_future:a' => [
+        'near_future:b' => [
             'eduPersonPrincipalName' => ['NEAR_FUTURE@ssp-idp1.local'],
             'sn' => ['Future'],
             'givenName' => ['Near'],
@@ -35,7 +35,7 @@ $config = [
                 gmdate('YmdHis\Z', strtotime('+1 day')), // Very soon
             ],
         ],
-        'already_past:a' => [
+        'already_past:c' => [
             'eduPersonPrincipalName' => ['ALREADY_PAST@ssp-idp1.local'],
             'sn' => ['Past'],
             'givenName' => ['Already'],
@@ -44,6 +44,25 @@ $config = [
             'cn' => ['ALREADY_PAST'],
             'schacExpiryDate' => [
                 gmdate('YmdHis\Z', strtotime('-1 day')), // In the past
+            ],
+        ],
+        'missing_exp:d' => [
+            'eduPersonPrincipalName' => ['MISSING_EXP@ssp-idp-1.local'],
+            'sn' => ['Expiration'],
+            'givenName' => ['Missing'],
+            'mail' => ['missing_exp@example.com'],
+            'employeeNumber' => ['44444'],
+            'cn' => ['MISSING_EXP'],
+        ],
+        'invalid_exp:e' => [
+            'eduPersonPrincipalName' => ['INVALID_EXP@ssp-idp-1.local'],
+            'sn' => ['Expiration'],
+            'givenName' => ['Invalid'],
+            'mail' => ['invalid_exp@example.com'],
+            'employeeNumber' => ['55555'],
+            'cn' => ['INVALID_EXP'],
+            'schacExpiryDate' => [
+                'invalid'
             ],
         ],
     ],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,7 @@ services:
       - ./dockerbuild/run-tests.sh:/data/run-tests.sh
       - ./dockerbuild/apply-dictionaries-overrides.php:/data/apply-dictionaries-overrides.php
       - ./features:/data/features
+      - ./behat.yml:/data/behat.yml
       - ./tests:/data/tests
       - ./modules/expirychecker:/data/vendor/simplesamlphp/simplesamlphp/modules/expirychecker
     command: ["/data/run-tests.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   ssp:
     build: .
     volumes:
-      # Utilize custom certs 
+      # Utilize custom certs
       - ./development/ssp/cert:/data/vendor/simplesamlphp/simplesamlphp/cert
 
       # Utilize custom configs
@@ -11,6 +11,10 @@ services:
       
       # Configure the debugger
       - ./development/ssp/run-debug.sh:/data/run-debug.sh
+
+      # Local modules
+      - ./modules/expirychecker:/data/vendor/simplesamlphp/simplesamlphp/modules/expirychecker
+
     command: ["/data/run-debug.sh"]
     ports:
       - "80:80"
@@ -46,6 +50,7 @@ services:
       - ./dockerbuild/apply-dictionaries-overrides.php:/data/apply-dictionaries-overrides.php
       - ./features:/data/features
       - ./tests:/data/tests
+      - ./modules/expirychecker:/data/vendor/simplesamlphp/simplesamlphp/modules/expirychecker
     command: ["/data/run-tests.sh"]
 
   test-browser:
@@ -89,6 +94,9 @@ services:
 
       # Enable checking our test metadata
       - ./dockerbuild/run-metadata-tests.sh:/data/run-metadata-tests.sh
+
+      # Local modules
+      - ./modules/expirychecker:/data/vendor/simplesamlphp/simplesamlphp/modules/expirychecker
     command: /data/run-debug.sh
     ports:
       - "80:80"
@@ -125,6 +133,9 @@ services:
 
       # Enable checking our test metadata
       - ./dockerbuild/run-metadata-tests.sh:/data/run-metadata-tests.sh
+
+      # Local modules
+      - ./modules/expirychecker:/data/vendor/simplesamlphp/simplesamlphp/modules/expirychecker
     command: 'bash -c "/data/enable-exampleauth-module.sh && /data/run.sh"'
     ports:
       - "8085:80"
@@ -155,6 +166,9 @@ services:
       # Utilize custom metadata
       - ./development/idp2-local/metadata/saml20-idp-hosted.php:/data/vendor/simplesamlphp/simplesamlphp/metadata/saml20-idp-hosted.php
       - ./development/idp2-local/metadata/saml20-sp-remote.php:/data/vendor/simplesamlphp/simplesamlphp/metadata/saml20-sp-remote.php
+
+      # Local modules
+      - ./modules/expirychecker:/data/vendor/simplesamlphp/simplesamlphp/modules/expirychecker
     command: /data/run.sh
     ports:
       - "8086:80"
@@ -181,6 +195,9 @@ services:
 
       # Enable checking our test metadata
       - ./dockerbuild/run-metadata-tests.sh:/data/run-metadata-tests.sh
+
+      # Local modules
+      - ./modules/expirychecker:/data/vendor/simplesamlphp/simplesamlphp/modules/expirychecker
     ports:
       - "8081:80"
     environment:
@@ -204,6 +221,9 @@ services:
 
       # Utilize custom metadata
       - ./development/sp2-local/metadata/saml20-idp-remote.php:/data/vendor/simplesamlphp/simplesamlphp/metadata/saml20-idp-remote.php
+
+      # Local modules
+      - ./modules/expirychecker:/data/vendor/simplesamlphp/simplesamlphp/modules/expirychecker
     ports:
       - "8082:80"
     environment:

--- a/dockerbuild/run-integration-tests.sh
+++ b/dockerbuild/run-integration-tests.sh
@@ -11,8 +11,5 @@ whenavail "ssp-idp1.local" 80 10 echo IDP 1 ready
 whenavail "ssp-sp1.local"  80 10 echo SP 1 ready
 
 ./vendor/bin/behat \
-    --append-snippets \
-    --snippets-for=FeatureContext \
     --no-interaction \
-    --stop-on-failure #\
-    #--strict
+    --stop-on-failure

--- a/features/bootstrap/ExpiryContext.php
+++ b/features/bootstrap/ExpiryContext.php
@@ -1,8 +1,4 @@
 <?php
-namespace Sil\SspExpiryChecker\Behat\context;
-
-use Behat\Behat\Context\Context;
-use Behat\Mink\Driver\GoutteDriver;
 use Behat\Mink\Element\DocumentElement;
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Session;
@@ -11,32 +7,19 @@ use PHPUnit\Framework\Assert;
 /**
  * Defines application features from the specific context.
  */
-class ExpiryContext implements Context
+class ExpiryContext extends FeatureContext
 {
     protected $username = null;
     protected $password = null;
-    
+
     /**
      * The browser session, used for interacting with the website.
      *
      * @var Session
      */
     protected $session;
-    
-    /**
-     * Initializes context.
-     *
-     * Every scenario gets its own context instance.
-     * You can also pass arbitrary arguments to the
-     * context constructor through behat.yml.
-     */
-    public function __construct()
-    {
-        $driver = new GoutteDriver();
-        $this->session = new Session($driver);
-        $this->session->start();
-    }
-    
+
+
     /**
      * Assert that the given page has a form that contains the given text.
      *
@@ -58,7 +41,7 @@ class ExpiryContext implements Context
             $page->getHtml()
         ));
     }
-    
+
     /**
      * Assert that the given page does NOT have a form that contains the given
      * text.
@@ -80,7 +63,7 @@ class ExpiryContext implements Context
             }
         }
     }
-    
+
     /**
      * Get the login button from the given page.
      *
@@ -117,11 +100,9 @@ class ExpiryContext implements Context
      */
     public function iLogin()
     {
-        $this->session->visit('http://sp/module.php/core/authenticate.php?as=ssp-hub-idp');
-        $page = $this->session->getPage();
-        $page->fillField('username', $this->username);
-        $page->fillField('password', $this->password);
-        $this->submitLoginForm($page);
+        $this->fillField('username', $this->username);
+        $this->fillField('password', $this->password);
+        $this->pressButton('Login');
     }
 
     /**
@@ -129,8 +110,7 @@ class ExpiryContext implements Context
      */
     public function iShouldEndUpAtMyIntendedDestination()
     {
-        $page = $this->session->getPage();
-        Assert::assertContains('Your attributes', $page->getHtml());
+        $this->assertPageBodyContainsText('Your attributes');
     }
 
     /**
@@ -151,7 +131,7 @@ class ExpiryContext implements Context
         $page = $this->session->getPage();
         Assert::assertContains('will expire', $page->getHtml());
     }
-    
+
     /**
      * Submit the login form, including the secondary page's form (if
      * simpleSAMLphp shows another page because JavaScript isn't supported).
@@ -162,13 +142,13 @@ class ExpiryContext implements Context
     {
         $loginButton = $this->getLoginButton($page);
         $loginButton->click();
-        
+
         // SimpleSAMLphp 1.15 markup for secondary page:
         $postLoginSubmitButton = $page->findButton('postLoginSubmitButton');
         if ($postLoginSubmitButton instanceof NodeElement) {
             $postLoginSubmitButton->click();
         } else {
-            
+
             // SimpleSAMLphp 1.14 markup for secondary page:
             $body = $page->find('css', 'body');
             if ($body instanceof NodeElement) {

--- a/features/bootstrap/ExpiryContext.php
+++ b/features/bootstrap/ExpiryContext.php
@@ -1,0 +1,257 @@
+<?php
+namespace Sil\SspExpiryChecker\Behat\context;
+
+use Behat\Behat\Context\Context;
+use Behat\Mink\Driver\GoutteDriver;
+use Behat\Mink\Element\DocumentElement;
+use Behat\Mink\Element\NodeElement;
+use Behat\Mink\Session;
+use PHPUnit\Framework\Assert;
+
+/**
+ * Defines application features from the specific context.
+ */
+class ExpiryContext implements Context
+{
+    protected $username = null;
+    protected $password = null;
+    
+    /**
+     * The browser session, used for interacting with the website.
+     *
+     * @var Session
+     */
+    protected $session;
+    
+    /**
+     * Initializes context.
+     *
+     * Every scenario gets its own context instance.
+     * You can also pass arbitrary arguments to the
+     * context constructor through behat.yml.
+     */
+    public function __construct()
+    {
+        $driver = new GoutteDriver();
+        $this->session = new Session($driver);
+        $this->session->start();
+    }
+    
+    /**
+     * Assert that the given page has a form that contains the given text.
+     *
+     * @param string $text The text (or HTML) to search for.
+     * @param DocumentElement $page The page to search in.
+     * @return void
+     */
+    protected function assertFormContains($text, $page)
+    {
+        $forms = $page->findAll('css', 'form');
+        foreach ($forms as $form) {
+            if (strpos($form->getHtml(), $text) !== false) {
+                return;
+            }
+        }
+        Assert::fail(sprintf(
+            "No form found containing %s in this HTML:\n%s",
+            var_export($text, true),
+            $page->getHtml()
+        ));
+    }
+    
+    /**
+     * Assert that the given page does NOT have a form that contains the given
+     * text.
+     *
+     * @param string $text The text (or HTML) to search for.
+     * @param DocumentElement $page The page to search in.
+     * @return void
+     */
+    protected function assertFormNotContains($text, $page)
+    {
+        $forms = $page->findAll('css', 'form');
+        foreach ($forms as $form) {
+            if (strpos($form->getHtml(), $text) !== false) {
+                Assert::fail(sprintf(
+                    "Found a form containing %s in this HTML:\n%s",
+                    var_export($text, true),
+                    $page->getHtml()
+                ));
+            }
+        }
+    }
+    
+    /**
+     * Get the login button from the given page.
+     *
+     * @param DocumentElement $page The page.
+     * @return NodeElement
+     */
+    protected function getLoginButton($page)
+    {
+        $buttons = $page->findAll('css', 'button');
+        $loginButton = null;
+        foreach ($buttons as $button) {
+            $lcButtonText = strtolower($button->getText());
+            if (strpos($lcButtonText, 'login') !== false) {
+                $loginButton = $button;
+                break;
+            }
+        }
+        Assert::assertNotNull($loginButton, 'Failed to find the login button');
+        return $loginButton;
+    }
+
+    /**
+     * @Given I provide credentials that will expire in the distant future
+     */
+    public function iProvideCredentialsThatWillExpireInTheDistantFuture()
+    {
+        // See `development/idp-local/config/authsources.php` for options.
+        $this->username = 'distant_future';
+        $this->password = 'a';
+    }
+
+    /**
+     * @When I login
+     */
+    public function iLogin()
+    {
+        $this->session->visit('http://sp/module.php/core/authenticate.php?as=ssp-hub-idp');
+        $page = $this->session->getPage();
+        $page->fillField('username', $this->username);
+        $page->fillField('password', $this->password);
+        $this->submitLoginForm($page);
+    }
+
+    /**
+     * @Then I should end up at my intended destination
+     */
+    public function iShouldEndUpAtMyIntendedDestination()
+    {
+        $page = $this->session->getPage();
+        Assert::assertContains('Your attributes', $page->getHtml());
+    }
+
+    /**
+     * @Given I provide credentials that will expire very soon
+     */
+    public function iProvideCredentialsThatWillExpireVerySoon()
+    {
+        // See `development/idp-local/config/authsources.php` for options.
+        $this->username = 'near_future';
+        $this->password = 'b';
+    }
+
+    /**
+     * @Then I should see a warning that my password will expire soon
+     */
+    public function iShouldSeeAWarningThatMyPasswordWillExpireSoon()
+    {
+        $page = $this->session->getPage();
+        Assert::assertContains('will expire', $page->getHtml());
+    }
+    
+    /**
+     * Submit the login form, including the secondary page's form (if
+     * simpleSAMLphp shows another page because JavaScript isn't supported).
+     *
+     * @param DocumentElement $page The page.
+     */
+    protected function submitLoginForm($page)
+    {
+        $loginButton = $this->getLoginButton($page);
+        $loginButton->click();
+        
+        // SimpleSAMLphp 1.15 markup for secondary page:
+        $postLoginSubmitButton = $page->findButton('postLoginSubmitButton');
+        if ($postLoginSubmitButton instanceof NodeElement) {
+            $postLoginSubmitButton->click();
+        } else {
+            
+            // SimpleSAMLphp 1.14 markup for secondary page:
+            $body = $page->find('css', 'body');
+            if ($body instanceof NodeElement) {
+                $onload = $body->getAttribute('onload');
+                if ($onload === "document.getElementsByTagName('input')[0].click();") {
+                    $body->pressButton('Submit');
+                }
+            }
+        }
+    }
+
+    /**
+     * @Then there should be a way to go change my password now
+     */
+    public function thereShouldBeAWayToGoChangeMyPasswordNow()
+    {
+        $page = $this->session->getPage();
+        $this->assertFormContains('change', $page);
+    }
+
+    /**
+     * @Then there should be a way to continue without changing my password
+     */
+    public function thereShouldBeAWayToContinueWithoutChangingMyPassword()
+    {
+        $page = $this->session->getPage();
+        $this->assertFormContains('continue', $page);
+    }
+
+    /**
+     * @Given I provide credentials that have expired
+     */
+    public function iProvideCredentialsThatHaveExpired()
+    {
+        // See `development/idp-local/config/authsources.php` for options.
+        $this->username = 'already_past';
+        $this->password = 'c';
+    }
+
+    /**
+     * @Then I should see a message that my password has expired
+     */
+    public function iShouldSeeAMessageThatMyPasswordHasExpired()
+    {
+        $page = $this->session->getPage();
+        Assert::assertContains('has expired', $page->getHtml());
+    }
+
+    /**
+     * @Then there should NOT be a way to continue without changing my password
+     */
+    public function thereShouldNotBeAWayToContinueWithoutChangingMyPassword()
+    {
+        $page = $this->session->getPage();
+        $this->assertFormNotContains('continue', $page);
+    }
+
+    /**
+     * @Given I provide credentials that have no password expiration date
+     */
+    public function iProvideCredentialsThatHaveNoPasswordExpirationDate()
+    {
+        // See `development/idp-local/config/authsources.php` for options.
+        $this->username = 'missing_exp';
+        $this->password = 'd';
+    }
+
+    /**
+     * @Then I should see an error message
+     */
+    public function iShouldSeeAnErrorMessage()
+    {
+        $page = $this->session->getPage();
+        Assert::assertContains('An error occurred', $page->getHtml());
+    }
+
+    /**
+     * @Given I provide credentials that have an invalid password expiration date
+     */
+    public function iProvideCredentialsThatHaveAnInvalidPasswordExpirationDate()
+    {
+        // See `development/idp-local/config/authsources.php` for options.
+        $this->username = 'invalid_exp';
+        $this->password = 'e';
+    }
+}

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -144,23 +144,6 @@ class FeatureContext extends MinkContext
         $this->visit(self::SP1_LOGIN_PAGE);
     }
 
-    /**
-     * @When I log in as a user who's password is NOT about to expire
-     */
-    public function iLogInAsAUserWhosPasswordIsNotAboutToExpire()
-    {
-        $this->logInAs('distant_future', 'a');
-    }
-
-    /**
-     * @Then I should see a page indicating that I successfully logged in
-     */
-    public function iShouldSeeAPageIndicatingThatISuccessfullyLoggedIn()
-    {
-        $this->assertResponseStatus(200);
-        $this->assertPageBodyContainsText('Your attributes');
-    }
-    
     protected function assertPageBodyContainsText(string $expectedText)
     {
         $page = $this->session->getPage();
@@ -168,38 +151,6 @@ class FeatureContext extends MinkContext
         Assert::contains($body->getText(), $expectedText);
     }
 
-    /**
-     * @When I log in as a user whose password is about to expire
-     */
-    public function iLogInAsAUserWhosPasswordIsAboutToExpire()
-    {
-        $this->logInAs('near_future', 'b');
-    }
-
-    /**
-     * @Then I should see a page warning me that my password is about to expire
-     */
-    public function iShouldSeeAPageWarningMeThatMyPasswordIsAboutToExpire()
-    {
-        $this->assertPageBodyContainsText('Password expiring soon');
-    }
-
-    /**
-     * @When I log in as a user whose password has expired
-     */
-    public function iLogInAsAUserWhosPasswordHasExpired()
-    {
-        $this->logInAs('already_past', 'c');
-    }
-
-    /**
-     * @Then I should see a page telling me that my password has expired
-     */
-    public function iShouldSeeAPageTellingMeThatMyPasswordHasExpired()
-    {
-        $this->assertPageBodyContainsText('Your password has expired');
-    }
-    
     private static function ensureFolderExistsForTestFile($filePath)
     {
         $folder = dirname($filePath);

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -14,10 +14,10 @@ class FeatureContext extends MinkContext
     private const HUB_BAD_AUTH_SOURCE_URL = 'http://ssp-hub.local/module.php/core/authenticate.php?as=wrong';
     private const HUB_DISCO_URL = 'http://ssp-hub.local/module.php/core/authenticate.php?as=hub-discovery';
     private const HUB_HOME_URL = 'http://ssp-hub.local';
-    private const SP1_LOGIN_PAGE = 'http://ssp-sp1.local/module.php/core/authenticate.php?as=ssp-hub';
+    protected const SP1_LOGIN_PAGE = 'http://ssp-sp1.local/module.php/core/authenticate.php?as=ssp-hub';
     
     /** @var Session */
-    private $session;
+    protected $session;
     
     public function __construct()
     {
@@ -161,7 +161,7 @@ class FeatureContext extends MinkContext
         $this->assertPageBodyContainsText('Your attributes');
     }
     
-    private function assertPageBodyContainsText(string $expectedText)
+    protected function assertPageBodyContainsText(string $expectedText)
     {
         $page = $this->session->getPage();
         $body = $page->find('css', 'body');
@@ -169,11 +169,11 @@ class FeatureContext extends MinkContext
     }
 
     /**
-     * @When I log in as a user who's password is about to expire
+     * @When I log in as a user whose password is about to expire
      */
     public function iLogInAsAUserWhosPasswordIsAboutToExpire()
     {
-        $this->logInAs('near_future', 'a');
+        $this->logInAs('near_future', 'b');
     }
 
     /**
@@ -185,11 +185,11 @@ class FeatureContext extends MinkContext
     }
 
     /**
-     * @When I log in as a user who's password has expired
+     * @When I log in as a user whose password has expired
      */
     public function iLogInAsAUserWhosPasswordHasExpired()
     {
-        $this->logInAs('already_past', 'a');
+        $this->logInAs('already_past', 'c');
     }
 
     /**

--- a/features/expirychecker.feature
+++ b/features/expirychecker.feature
@@ -8,9 +8,38 @@ Feature: Expiry Checker module
     Then I should see a page indicating that I successfully logged in
     
   Scenario: Password is about to expire
-    When I log in as a user who's password is about to expire
+    When I log in as a user whose password is about to expire
     Then I should see a page warning me that my password is about to expire
     
   Scenario: Password has expired
-    When I log in as a user who's password has expired
+    When I log in as a user whose password has expired
     Then I should see a page telling me that my password has expired
+
+  Scenario: Password will expire in the distant future
+    Given I provide credentials that will expire in the distant future
+    When I login
+    Then I should end up at my intended destination
+
+  Scenario: Password will expire tomorrow
+    Given I provide credentials that will expire very soon
+    When I login
+    Then I should see a warning that my password will expire soon
+    And there should be a way to go change my password now
+    And there should be a way to continue without changing my password
+
+  Scenario: Password has expired
+    Given I provide credentials that have expired
+    When I login
+    Then I should see a message that my password has expired
+    And there should be a way to go change my password now
+    But there should NOT be a way to continue without changing my password
+
+  Scenario: Reject missing expiration date
+    Given I provide credentials that have no password expiration date
+    When I login
+    Then I should see an error message
+
+  Scenario: Reject invalid expiration date
+    Given I provide credentials that have an invalid password expiration date
+    When I login
+    Then I should see an error message

--- a/features/expirychecker.feature
+++ b/features/expirychecker.feature
@@ -2,18 +2,6 @@ Feature: Expiry Checker module
   Background:
     Given I go to the SP1 login page
       And I click on the "IDP 1" tile
-  
-  Scenario: Password is not about to expire
-    When I log in as a user who's password is NOT about to expire
-    Then I should see a page indicating that I successfully logged in
-    
-  Scenario: Password is about to expire
-    When I log in as a user whose password is about to expire
-    Then I should see a page warning me that my password is about to expire
-    
-  Scenario: Password has expired
-    When I log in as a user whose password has expired
-    Then I should see a page telling me that my password has expired
 
   Scenario: Password will expire in the distant future
     Given I provide credentials that will expire in the distant future

--- a/modules/expirychecker/lib/Auth/Process/ExpiryDate.php
+++ b/modules/expirychecker/lib/Auth/Process/ExpiryDate.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SimpleSAML\Module\ExpiryChecker\Auth\Process;
+namespace SimpleSAML\Module\expirychecker\Auth\Process;
 
 use Psr\Log\LoggerInterface;
 use Sil\Psr3Adapters\Psr3SamlLogger;
@@ -8,8 +8,8 @@ use SimpleSAML\Auth\ProcessingChain;
 use SimpleSAML\Auth\ProcessingFilter;
 use SimpleSAML\Auth\State;
 use SimpleSAML\Module;
-use SimpleSAML\Module\ExpiryChecker\Utilities;
-use SimpleSAML\Module\ExpiryChecker\Validator;
+use SimpleSAML\Module\expirychecker\Utilities;
+use SimpleSAML\Module\expirychecker\Validator;
 use SimpleSAML\Session;
 use SimpleSAML\Utils\HTTP;
 

--- a/modules/expirychecker/lib/Auth/Process/ExpiryDate.php
+++ b/modules/expirychecker/lib/Auth/Process/ExpiryDate.php
@@ -4,12 +4,12 @@ namespace SimpleSAML\Module\expirychecker\Auth\Process;
 
 use Psr\Log\LoggerInterface;
 use Sil\Psr3Adapters\Psr3SamlLogger;
-use Sil\SspExpiryChecker\Validator;
 use SimpleSAML\Auth\ProcessingChain;
 use SimpleSAML\Auth\ProcessingFilter;
 use SimpleSAML\Auth\State;
 use SimpleSAML\Module;
 use SimpleSAML\Module\expirychecker\Utilities;
+use SimpleSAML\Module\expirychecker\Validator;
 use SimpleSAML\Session;
 use SimpleSAML\Utils\HTTP;
 
@@ -45,9 +45,7 @@ class ExpiryDate extends ProcessingFilter
     public function __construct($config, $reserved)
     {
         parent::__construct($config, $reserved);
-        
-        $this->initComposerAutoloader();
-        
+
         assert('is_array($config)');
         
         $this->initLogger($config);
@@ -175,15 +173,7 @@ class ExpiryDate extends ProcessingFilter
         );
         $session->save();
     }
-    
-    protected function initComposerAutoloader()
-    {
-        $path = __DIR__ . '/../../../vendor/autoload.php';
-        if (file_exists($path)) {
-            require_once $path;
-        }
-    }
-    
+
     protected function initLogger($config)
     {
         $loggerClass = $config['loggerClass'] ?? Psr3SamlLogger::class;

--- a/modules/expirychecker/lib/Auth/Process/ExpiryDate.php
+++ b/modules/expirychecker/lib/Auth/Process/ExpiryDate.php
@@ -1,0 +1,420 @@
+<?php
+
+namespace SimpleSAML\Module\expirychecker\Auth\Process;
+
+use Psr\Log\LoggerInterface;
+use Sil\Psr3Adapters\Psr3SamlLogger;
+use Sil\SspExpiryChecker\Validator;
+use SimpleSAML\Auth\ProcessingChain;
+use SimpleSAML\Auth\ProcessingFilter;
+use SimpleSAML\Auth\State;
+use SimpleSAML\Module;
+use SimpleSAML\Module\expirychecker\Utilities;
+use SimpleSAML\Session;
+use SimpleSAML\Utils\HTTP;
+
+/**
+ * Filter which either warns the user that their password is "about to expire"
+ * (giving them the option of changing it now or later) or tells them that it
+ * has expired (only allowing them to go change their password).
+ *
+ * See README.md for sample (and explanation of) expected configuration.
+ */
+class ExpiryDate extends ProcessingFilter
+{
+    const HAS_SEEN_SPLASH_PAGE = 'has_seen_splash_page';
+    const SESSION_TYPE = 'expirychecker';
+    
+    private $warnDaysBefore = 14;
+    private $originalUrlParam = 'originalurl';
+    private $passwordChangeUrl = null;
+    private $accountNameAttr = null;
+    private $employeeIdAttr = 'employeeNumber';
+    private $expiryDateAttr = null;
+    private $dateFormat = 'Y-m-d';
+    
+    /** @var LoggerInterface */
+    protected $logger;
+    
+    /**
+     * Initialize this filter.
+     *
+     * @param array $config  Configuration information about this filter.
+     * @param mixed $reserved  For future use.
+     */
+    public function __construct($config, $reserved)
+    {
+        parent::__construct($config, $reserved);
+        
+        $this->initComposerAutoloader();
+        
+        assert('is_array($config)');
+        
+        $this->initLogger($config);
+        
+        $this->loadValuesFromConfig($config, [
+            'warnDaysBefore' => [
+                Validator::INT,
+            ],
+            'originalUrlParam' => [
+                Validator::STRING,
+                Validator::NOT_EMPTY,
+            ],
+            'passwordChangeUrl' => [
+                Validator::STRING,
+                Validator::NOT_EMPTY,
+            ],
+            'accountNameAttr' => [
+                Validator::STRING,
+                Validator::NOT_EMPTY,
+            ],
+            'expiryDateAttr' => [
+                Validator::STRING,
+                Validator::NOT_EMPTY,
+            ],
+            'dateFormat' => [
+                Validator::STRING,
+                Validator::NOT_EMPTY,
+            ],
+        ]);
+    }
+    
+    protected function loadValuesFromConfig($config, $attributeRules)
+    {
+        foreach ($attributeRules as $attribute => $rules) {
+            if (array_key_exists($attribute, $config)) {
+                $this->$attribute = $config[$attribute];
+            }
+            
+            Validator::validate($this->$attribute, $rules, $this->logger, $attribute);
+        }
+    }
+    
+    /**
+     * Get the specified attribute from the given state data.
+     *
+     * NOTE: If the attribute's data is an array, the first value will be
+     *       returned. Otherwise, the attribute's data will simply be returned
+     *       as-is.
+     *
+     * @param string $attributeName The name of the attribute.
+     * @param array $state The state data.
+     * @return mixed The attribute value, or null if not found.
+     */
+    protected function getAttribute($attributeName, $state)
+    {
+        $attributeData = $state['Attributes'][$attributeName] ?? null;
+        
+        if (is_array($attributeData)) {
+            return $attributeData[0] ?? null;
+        }
+        
+        return $attributeData;
+    }
+    
+    /**
+     * Calculate how many days remain between now and when the password will
+     * expire.
+     *
+     * @param int $expiryTimestamp The timestamp for when the password will
+     *     expire.
+     * @return int The number of days remaining
+     */
+    protected function getDaysLeftBeforeExpiry($expiryTimestamp)
+    {
+        $now = time();
+        $end = $expiryTimestamp;
+        return round(($end - $now) / (24*60*60));
+    }
+    
+    /**
+     * Get the timestamp for when the user's password will expire, throwing an
+     * exception if unable to do so.
+     *
+     * @param string $expiryDateAttr The name of the attribute where the
+     *     expiration date (as a string) is stored.
+     * @param array $state The state data.
+     * @return int The expiration timestamp.
+     * @throws \Exception
+     */
+    protected function getExpiryTimestamp($expiryDateAttr, $state)
+    {
+        $expiryDateString = $this->getAttribute($expiryDateAttr, $state);
+        
+        // Ensure that EVERY user login provides a usable password expiration date.
+        $expiryTimestamp = strtotime($expiryDateString) ?: null;
+        if (empty($expiryTimestamp)) {
+            throw new \Exception(sprintf(
+                "We could not understand the expiration date (%s, from %s) for "
+                . "the user's password, so we do not know whether their "
+                . "password is still valid.",
+                var_export($expiryDateString, true),
+                var_export($expiryDateAttr, true)
+            ), 1496843359);
+        }
+        return $expiryTimestamp;
+    }
+    
+    public static function hasSeenSplashPageRecently()
+    {
+        $session = Session::getSessionFromRequest();
+        return (bool)$session->getData(
+            self::SESSION_TYPE,
+            self::HAS_SEEN_SPLASH_PAGE
+        );
+    }
+    
+    public static function skipSplashPagesFor($seconds)
+    {
+        $session = Session::getSessionFromRequest();
+        $session->setData(
+            self::SESSION_TYPE,
+            self::HAS_SEEN_SPLASH_PAGE,
+            true,
+            $seconds
+        );
+        $session->save();
+    }
+    
+    protected function initComposerAutoloader()
+    {
+        $path = __DIR__ . '/../../../vendor/autoload.php';
+        if (file_exists($path)) {
+            require_once $path;
+        }
+    }
+    
+    protected function initLogger($config)
+    {
+        $loggerClass = $config['loggerClass'] ?? Psr3SamlLogger::class;
+        $this->logger = new $loggerClass();
+        if (! $this->logger instanceof LoggerInterface) {
+            throw new \Exception(sprintf(
+                'The specified loggerClass (%s) does not implement '
+                . '\\Psr\\Log\\LoggerInterface.',
+                var_export($loggerClass, true)
+            ), 1496928725);
+        }
+    }
+    
+    /**
+     * See if the given timestamp is in the past.
+     *
+     * @param int $timestamp The timestamp to check.
+     * @return bool
+     */
+    public function isDateInPast(int $timestamp)
+    {
+        return ($timestamp < time());
+    }
+    
+    /**
+     * Check whether the user's password has expired.
+     *
+     * @param int $expiryTimestamp The timestamp for when the user's password
+     *     will expire.
+     * @return bool
+     */
+    public function isExpired(int $expiryTimestamp)
+    {
+        return $this->isDateInPast($expiryTimestamp);
+    }
+    
+    /**
+     * Check whether it's time to warn the user that they will need to change
+     * their password soon.
+     *
+     * @param int $expiryTimestamp The timestamp for when the password expires.
+     * @param int $warnDaysBefore How many days before the expiration we should
+     *     warn the user.
+     * @return boolean
+     */
+    public function isTimeToWarn($expiryTimestamp, $warnDaysBefore)
+    {
+        $daysLeft = $this->getDaysLeftBeforeExpiry($expiryTimestamp);
+        return ($daysLeft <= $warnDaysBefore);
+    }
+
+    /**
+     * Redirect the user to the change password url if they haven't gone
+     *   there in the last 10 minutes
+     * @param array $state
+     * @param string $accountName
+     * @param string $passwordChangeUrl
+     * @param string $change_pwd_session
+     * @param int $expiryTimestamp The timestamp when the password will expire.
+     */
+    public function redirect2PasswordChange(
+        &$state,
+        $accountName,
+        $passwordChangeUrl,
+        $change_pwd_session,
+        $expiryTimestamp
+    ) {
+        $sessionType = 'expirychecker';
+        /* Save state and redirect. */
+        $state['expiresAtTimestamp'] = $expiryTimestamp;
+        $state['accountName'] = $accountName;
+        $id = State::saveState(
+            $state,
+            'expirychecker:redirected_to_password_change_url'
+        );
+        $ignoreMinutes = 60;
+
+        $session = Session::getSessionFromRequest();
+        $idpExpirySession = $session->getData($sessionType, $change_pwd_session);
+        
+        // If the session shows that the User already passed this way,
+        //  don't redirect to change password page
+        if ($idpExpirySession !== null) {
+            ProcessingChain::resumeProcessing($state);
+        } else {
+            // Otherwise, set a value to tell us they've probably changed
+            // their password, in order to allow password to get propagated
+            $session->setData(
+                $sessionType,
+                $change_pwd_session,
+                1,
+                (60 * $ignoreMinutes)
+            );
+            $session->save();
+        }
+        
+        
+        /* If state already has the change password url, go straight there to
+         * avoid eternal loop between that and the idp. Otherwise add the
+         * original destination url as a parameter.  */
+        if (array_key_exists('saml:RelayState', $state)) {
+            $relayState = $state['saml:RelayState'];
+            if (strpos($relayState, $passwordChangeUrl) !== false) {
+                ProcessingChain::resumeProcessing($state);
+            } else {
+                $returnTo = Utilities::getUrlFromRelayState(
+                    $relayState
+                );
+                if (! empty($returnTo)) {
+                    $passwordChangeUrl .= '?returnTo=' . $returnTo;
+                }
+            }
+        }
+
+        $this->logger->warning(json_encode([
+            'event' => 'expirychecker: redirecting to change password',
+            'accountName' => $accountName,
+            'passwordChangeUrl' => $passwordChangeUrl,
+        ]));
+
+        HTTP::redirectTrustedURL($passwordChangeUrl, array());
+    }
+    
+    /**
+     * Apply this AuthProc Filter.
+     *
+     * @param array &$state The current state.
+     */
+    public function process(&$state)
+    {
+        $employeeId = $this->getAttribute($this->employeeIdAttr, $state);
+        
+        /* If the user has already seen a splash page from this AuthProc
+         * recently, simply let them pass on through (so they can get into the
+         * change-password website, for example).  */
+        if (self::hasSeenSplashPageRecently()) {
+            $this->logger->warning(json_encode([
+                'event' => 'expirychecker: skip message, seen recently',
+                'employeeId' => $employeeId,
+            ]));
+            return;
+        }
+        
+        // Get the necessary info from the state data.
+        $accountName = $this->getAttribute($this->accountNameAttr, $state);
+        $expiryTimestamp = $this->getExpiryTimestamp($this->expiryDateAttr, $state);
+        
+        $this->logger->warning(json_encode([
+            'event' => 'expirychecker: will check expiration date',
+            'employeeId' => $employeeId,
+            'accountName' => $accountName,
+            'expiryDateAttrValue' => $this->getAttribute($this->expiryDateAttr, $state),
+            'expiryTimestamp' => $expiryTimestamp,
+        ]));
+        
+        if ($this->isExpired($expiryTimestamp)) {
+            $this->redirectToExpiredPage($state, $accountName, $expiryTimestamp);
+        }
+        
+        // Display a password expiration warning page if it's time to do so.
+        if ($this->isTimeToWarn($expiryTimestamp, $this->warnDaysBefore)) {
+            $this->redirectToWarningPage($state, $accountName, $expiryTimestamp);
+        }
+        
+        $this->logger->warning(json_encode([
+            'event' => 'expirychecker: no action necessary',
+            'employeeId' => $employeeId,
+        ]));
+    }
+    
+    /**
+     * Redirect the user to the expired-password page.
+     *
+     * @param array $state The state data.
+     * @param string $accountName The name of the user account.
+     * @param int $expiryTimestamp When the password expired.
+     */
+    public function redirectToExpiredPage(&$state, $accountName, $expiryTimestamp)
+    {
+        assert('is_array($state)');
+        
+        $this->logger->warning(json_encode([
+            'event' => 'expirychecker: password expired',
+            'accountName' => $accountName,
+        ]));
+
+        /* Save state and redirect. */
+        $state['expiresAtTimestamp'] = $expiryTimestamp;
+        $state['accountName'] = $accountName;
+        $state['passwordChangeUrl'] = $this->passwordChangeUrl;
+        $state['originalUrlParam'] = $this->originalUrlParam;
+        
+        $id = State::saveState($state, 'expirychecker:expired');
+        $url = Module::getModuleURL('expirychecker/expired.php');
+
+        HTTP::redirectTrustedURL($url, array('StateId' => $id));
+    }
+    
+    /**
+     * Redirect the user to the warning page.
+     *
+     * @param array $state The state data.
+     * @param string $accountName The name of the user account.
+     * @param int $expiryTimestamp When the password will expire.
+     */
+    protected function redirectToWarningPage(&$state, $accountName, $expiryTimestamp)
+    {
+        assert('is_array($state)');
+        
+        $this->logger->warning(json_encode([
+            'event' => 'expirychecker: about to expire',
+            'accountName' => $accountName,
+        ]));
+        
+        $daysLeft = $this->getDaysLeftBeforeExpiry($expiryTimestamp);
+        $state['daysLeft'] = $daysLeft;
+        
+        if (isset($state['isPassive']) && $state['isPassive'] === true) {
+            /* We have a passive request. Skip the warning. */
+            return;
+        }
+        
+        /* Save state and redirect. */
+        $state['expiresAtTimestamp'] = $expiryTimestamp;
+        $state['accountName'] = $accountName;
+        $state['passwordChangeUrl'] = $this->passwordChangeUrl;
+        $state['originalUrlParam'] = $this->originalUrlParam;
+        
+        $id = State::saveState($state, 'expirychecker:about2expire');
+        $url = Module::getModuleURL('expirychecker/about2expire.php');
+
+        HTTP::redirectTrustedURL($url, array('StateId' => $id));
+    }
+}

--- a/modules/expirychecker/lib/Auth/Process/ExpiryDate.php
+++ b/modules/expirychecker/lib/Auth/Process/ExpiryDate.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SimpleSAML\Module\expirychecker\Auth\Process;
+namespace SimpleSAML\Module\ExpiryChecker\Auth\Process;
 
 use Psr\Log\LoggerInterface;
 use Sil\Psr3Adapters\Psr3SamlLogger;
@@ -8,8 +8,8 @@ use SimpleSAML\Auth\ProcessingChain;
 use SimpleSAML\Auth\ProcessingFilter;
 use SimpleSAML\Auth\State;
 use SimpleSAML\Module;
-use SimpleSAML\Module\expirychecker\Utilities;
-use SimpleSAML\Module\expirychecker\Validator;
+use SimpleSAML\Module\ExpiryChecker\Utilities;
+use SimpleSAML\Module\ExpiryChecker\Validator;
 use SimpleSAML\Session;
 use SimpleSAML\Utils\HTTP;
 

--- a/modules/expirychecker/lib/Utilities.php
+++ b/modules/expirychecker/lib/Utilities.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SimpleSAML\Module\ExpiryChecker;
+namespace SimpleSAML\Module\expirychecker;
 
 class Utilities {
 

--- a/modules/expirychecker/lib/Utilities.php
+++ b/modules/expirychecker/lib/Utilities.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace SimpleSAML\Module\expirychecker;
+
+class Utilities {
+
+  /**
+  * Expects three strings for a url and what marks out the beginning
+  * and end of the domain. 
+  * 
+  * Returns a string with the domain portion of the url (e.g. www.insitehome.org)
+  */
+    public static function getUrlDomain($in_url, $start_marker='//', 
+                                        $end_marker='/') {
+    
+        $sm_len = strlen($start_marker);
+        $em_len = strlen($end_marker);
+        $start_pos = strpos($in_url, $start_marker);
+        $domain = substr($in_url, $start_pos + $sm_len);
+      
+        $end_pos = strpos($domain, $end_marker);
+        $domain = substr($domain, 0, $end_pos);
+        return $domain;
+    }
+
+        /**
+         * Expects six strings for a url and what marks out the beginning
+         * and end of its domain and then the same again for a second url.
+         *
+         * Returns 1 if the domains of the two urls are the same and 0 otherwise.
+         */
+    public static function haveSameDomain($url1, $start_marker1,
+                                        $end_marker1, $url2, $start_marker2='//', 
+                                        $end_marker2='/') {
+        $domain1 = self::getUrlDomain($url1, $start_marker1, $end_marker1);
+        $domain2 = self::getUrlDomain($url2, $start_marker2, $end_marker2);
+                    
+        if ($domain1 === $domain2) {
+          return 1;
+        }
+        return 0;
+    }
+
+        /**
+         * Expects four strings for ...
+         *  - the url for changing the user's password,
+  *  - the parameter label for the original url the user was headed to
+  *  - the original url the user was headed to
+  *  - the StateId parameter to add to the end of the new version of the url
+  * Returns a string with special symbols urlencoded and then also encoded 
+  *  for apex to use. If the domains of the change password url and the 
+  *  original url are different, it appends the StateId to the output.
+         */
+    public static function convertOriginalUrl($passwordChangeUrl,
+                                  $originalUrlParam, $originalUrl, $stateId ) {
+        $sameDomain = self::haveSameDomain($passwordChangeUrl,
+          '//', '/', $originalUrl, '//', '/');
+        $original = $originalUrlParam . ":" . urlencode($originalUrl);
+        // make changes that insite/apex needs in url
+        $original = str_replace('%3A', '*COLON*', $original);
+        $original = str_replace('%2C', '*COMMA*', $original);
+        $original = str_replace('%26', '*AMPER*', $original);
+
+        // if it already has a ?, then give it a &
+        // otherwise give it a ? ...
+        //  and then the StateId param
+        if (!$sameDomain) {
+            if (strpos($original, '%3F') !== false) {
+                $original = $original . "*AMPER*" . $stateId;
+            } else {
+                $original = $original . '%3F' . $stateId;
+            }
+        }
+        return $original;
+    }
+    
+    /**
+     * If the $relayState begins with "http", returns it.
+     *   Otherwise, returns empty string.
+     * @param string $relayState
+     * @return string
+     **/
+    public static function getUrlFromRelayState($relayState) {
+        if (strpos($relayState, "http") === 0) {
+            return $relayState;
+        }
+        
+        return '';
+    }
+}
+
+

--- a/modules/expirychecker/lib/Utilities.php
+++ b/modules/expirychecker/lib/Utilities.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SimpleSAML\Module\expirychecker;
+namespace SimpleSAML\Module\ExpiryChecker;
 
 class Utilities {
 

--- a/modules/expirychecker/lib/Validator.php
+++ b/modules/expirychecker/lib/Validator.php
@@ -1,5 +1,6 @@
 <?php
-namespace Sil\SspExpiryChecker;
+
+namespace SimpleSAML\Module\expirychecker;
 
 use Exception;
 use InvalidArgumentException;

--- a/modules/expirychecker/lib/Validator.php
+++ b/modules/expirychecker/lib/Validator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SimpleSAML\Module\ExpiryChecker;
+namespace SimpleSAML\Module\expirychecker;
 
 use Exception;
 use InvalidArgumentException;

--- a/modules/expirychecker/lib/Validator.php
+++ b/modules/expirychecker/lib/Validator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SimpleSAML\Module\expirychecker;
+namespace SimpleSAML\Module\ExpiryChecker;
 
 use Exception;
 use InvalidArgumentException;

--- a/modules/expirychecker/src/Validator.php
+++ b/modules/expirychecker/src/Validator.php
@@ -1,0 +1,71 @@
+<?php
+namespace Sil\SspExpiryChecker;
+
+use Exception;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+
+class Validator
+{
+    const INT = 'int';
+    const NOT_EMPTY = 'not empty';
+    const STRING = 'string';
+    
+    /**
+     * Validate the given value against the specified rules.
+     *
+     * @param mixed $value The value to check.
+     * @param string[] $rules The list of rules (see this class's constants).
+     * @param LoggerInterface $logger The logger.
+     * @throws Exception
+     */
+    public static function validate($value, $rules, $logger, $attribute)
+    {
+        foreach ($rules as $rule) {
+            if ( ! self::isValid($value, $rule, $logger)) {
+                
+                $exception = new Exception(sprintf(
+                    'The value we have for %s (%s) does not meet the following validation rule: %s.',
+                    $attribute,
+                    var_export($value, true),
+                    $rule
+                ), 1496867717);
+                
+                $logger->critical($exception->getMessage());
+                throw $exception;
+            }
+        }
+    }
+    
+    /**
+     * See if the given value satisfies the specified rule.
+     *
+     * @param mixed $value The value to check.
+     * @param string $rule The rule (see this class's constants).
+     * @param LoggerInterface $logger The logger.
+     * @return bool
+     * @throws InvalidArgumentException
+     */
+    protected static function isValid($value, $rule, $logger)
+    {
+        switch ($rule) {
+            case self::INT:
+                return is_int($value);
+                
+            case self::NOT_EMPTY:
+                return !empty($value);
+                
+            case self::STRING:
+                return is_string($value);
+                
+            default:
+                $exception = new InvalidArgumentException(sprintf(
+                    'Unknown validation rule: %s',
+                    var_export($rule, true)
+                ), 1496866914);
+                
+                $logger->critical($exception->getMessage());
+                throw $exception;
+        }
+    }
+}

--- a/modules/expirychecker/templates/about2expire.php
+++ b/modules/expirychecker/templates/about2expire.php
@@ -1,0 +1,48 @@
+<?php
+/* @var $this \SimpleSAML\XHTML\Template */
+
+$this->data['header'] = sprintf(
+    'Your password will expire in %s %s',
+    $this->data['daysLeft'],
+    $this->data['dayOrDays']
+);
+$this->data['autofocus'] = 'yesbutton';
+
+$this->includeAtTemplateBase('includes/header.php');
+
+$dateString = msgfmt_format_message(
+    $this->getLanguage(),
+    '{0,date,long}',
+    [$this->data['expiresAtTimestamp']]
+);
+
+?>
+<p>
+  The password for your <?= htmlentities($this->data['accountName']); ?>
+  account will expire on <b><?= htmlentities($dateString); ?></b>.
+</p>
+<p>
+  Would you like to update your password now?
+</p>
+
+<form action="<?= htmlentities($this->data['formTarget']); ?>">
+  
+    <?php foreach ($this->data['formData'] as $name => $value): ?>
+        <input type="hidden"
+               name="<?= htmlentities($name); ?>"
+               value="<?= htmlentities($value); ?>" />
+    <?php endforeach; ?>
+    
+    <button type="submit" id="yesbutton" name="changepwd"
+            style="padding: 4px 8px;">
+        Yes, update password
+    </button>
+    
+    <button type="submit" id="nobutton" name="continue"
+            style="padding: 4px 8px;">
+        No, continue where I was going
+    </button>
+</form>
+<?php
+
+$this->includeAtTemplateBase('includes/footer.php');

--- a/modules/expirychecker/templates/expired.php
+++ b/modules/expirychecker/templates/expired.php
@@ -1,0 +1,38 @@
+<?php
+
+$this->data['header'] = 'Your password has expired';
+
+$this->includeAtTemplateBase('includes/header.php');
+
+$dateString = msgfmt_format_message(
+    $this->getLanguage(),
+    '{0,date,long}',
+    [$this->data['expiresAtTimestamp']]
+);
+
+?>
+<p>
+  The password for your <?= htmlentities($this->data['accountName']); ?>
+  account expired on <?= htmlentities($dateString); ?>.
+</p>
+<p>
+  You will need to update your password before you can continue to where you
+  were going.
+</p>
+<p>
+<form action="<?= htmlentities($this->data['formTarget']); ?>">
+  
+    <?php foreach ($this->data['formData'] as $name => $value): ?>
+        <input type="hidden"
+               name="<?= htmlentities($name); ?>"
+               value="<?= htmlentities($value); ?>" />
+    <?php endforeach; ?>
+    
+    <button type="submit" id="yesbutton" name="changepwd"
+            style="padding: 4px 8px;">
+        Update password
+    </button>
+</form>
+<?php
+
+$this->includeAtTemplateBase('includes/footer.php');

--- a/modules/expirychecker/www/about2expire.php
+++ b/modules/expirychecker/www/about2expire.php
@@ -1,0 +1,65 @@
+<?php
+
+use SimpleSAML\Auth\ProcessingChain;
+use SimpleSAML\Auth\State;
+use SimpleSAML\Configuration;
+use SimpleSAML\Error\BadRequest;
+use SimpleSAML\Logger;
+use SimpleSAML\Module;
+use SimpleSAML\Module\expirychecker\Auth\Process\ExpiryDate;
+use SimpleSAML\Module\expirychecker\Utilities;
+use SimpleSAML\Utils\HTTP;
+use SimpleSAML\XHTML\Template;
+
+$stateId = filter_input(INPUT_GET, 'StateId') ?? null;
+if (empty($stateId)) {
+    throw new BadRequest('Missing required StateId query parameter.');
+}
+
+$state = State::loadState($stateId, 'expirychecker:about2expire');
+
+/* Skip the splash pages for awhile, both to let the user get to the
+ * change-password website and to avoid annoying them with constant warnings. */
+ExpiryDate::skipSplashPagesFor(14400); // 14400 seconds = 4 hours
+
+if (array_key_exists('continue', $_REQUEST)) {
+
+    // The user has pressed the continue button.
+    ProcessingChain::resumeProcessing($state);
+}
+
+if (array_key_exists('changepwd', $_REQUEST)) {
+
+    // The user has pressed the change-password button.
+    $passwordChangeUrl = $state['passwordChangeUrl'];
+
+    // Add the original url as a parameter
+    if (array_key_exists('saml:RelayState', $state)) {
+        $stateId = State::saveState(
+            $state,
+            'expirychecker:about2expire'
+        );
+
+        $returnTo = Utilities::getUrlFromRelayState(
+            $state['saml:RelayState']
+        );
+        if (! empty($returnTo)) {
+            $passwordChangeUrl .= '?returnTo=' . $returnTo;
+        }
+    }
+
+    HTTP::redirectTrustedURL($passwordChangeUrl, array());
+}
+
+$globalConfig = Configuration::getInstance();
+
+$t = new Template($globalConfig, 'expirychecker:about2expire.php');
+$t->data['formTarget'] = Module::getModuleURL('expirychecker/about2expire.php');
+$t->data['formData'] = ['StateId' => $stateId];
+$t->data['daysLeft'] = $state['daysLeft'];
+$t->data['dayOrDays'] = (intval($state['daysLeft']) === 1 ? 'day' : 'days');
+$t->data['expiresAtTimestamp'] = $state['expiresAtTimestamp'];
+$t->data['accountName'] = $state['accountName'];
+$t->show();
+
+Logger::info('expirychecker - User has been warned that their password will expire soon.');

--- a/modules/expirychecker/www/about2expire.php
+++ b/modules/expirychecker/www/about2expire.php
@@ -6,8 +6,8 @@ use SimpleSAML\Configuration;
 use SimpleSAML\Error\BadRequest;
 use SimpleSAML\Logger;
 use SimpleSAML\Module;
-use SimpleSAML\Module\expirychecker\Auth\Process\ExpiryDate;
-use SimpleSAML\Module\expirychecker\Utilities;
+use SimpleSAML\Module\ExpiryChecker\Auth\Process\ExpiryDate;
+use SimpleSAML\Module\ExpiryChecker\Utilities;
 use SimpleSAML\Utils\HTTP;
 use SimpleSAML\XHTML\Template;
 

--- a/modules/expirychecker/www/about2expire.php
+++ b/modules/expirychecker/www/about2expire.php
@@ -6,8 +6,8 @@ use SimpleSAML\Configuration;
 use SimpleSAML\Error\BadRequest;
 use SimpleSAML\Logger;
 use SimpleSAML\Module;
-use SimpleSAML\Module\ExpiryChecker\Auth\Process\ExpiryDate;
-use SimpleSAML\Module\ExpiryChecker\Utilities;
+use SimpleSAML\Module\expirychecker\Auth\Process\ExpiryDate;
+use SimpleSAML\Module\expirychecker\Utilities;
 use SimpleSAML\Utils\HTTP;
 use SimpleSAML\XHTML\Template;
 

--- a/modules/expirychecker/www/expired.php
+++ b/modules/expirychecker/www/expired.php
@@ -5,8 +5,8 @@ use SimpleSAML\Configuration;
 use SimpleSAML\Error\BadRequest;
 use SimpleSAML\Logger;
 use SimpleSAML\Module;
-use SimpleSAML\Module\expirychecker\Auth\Process\ExpiryDate;
-use SimpleSAML\Module\expirychecker\Utilities;
+use SimpleSAML\Module\ExpiryChecker\Auth\Process\ExpiryDate;
+use SimpleSAML\Module\ExpiryChecker\Utilities;
 use SimpleSAML\Utils\HTTP;
 use SimpleSAML\XHTML\Template;
 

--- a/modules/expirychecker/www/expired.php
+++ b/modules/expirychecker/www/expired.php
@@ -1,0 +1,56 @@
+<?php
+
+use SimpleSAML\Auth\State;
+use SimpleSAML\Configuration;
+use SimpleSAML\Error\BadRequest;
+use SimpleSAML\Logger;
+use SimpleSAML\Module;
+use SimpleSAML\Module\expirychecker\Auth\Process\ExpiryDate;
+use SimpleSAML\Module\expirychecker\Utilities;
+use SimpleSAML\Utils\HTTP;
+use SimpleSAML\XHTML\Template;
+
+$stateId = filter_input(INPUT_GET, 'StateId') ?? null;
+if (empty($stateId)) {
+    throw new BadRequest('Missing required StateId query parameter.');
+}
+
+$state = State::loadState($stateId, 'expirychecker:expired');
+
+if (array_key_exists('changepwd', $_REQUEST)) {
+    
+    /* Now that they've clicked change-password, skip the splash pages very
+     * briefly, to let the user get to the change-password website.  */
+    ExpiryDate::skipSplashPagesFor(60); // 60 seconds = 1 minute
+    
+    // The user has pressed the change-password button.
+    $passwordChangeUrl = $state['passwordChangeUrl'];
+    
+    // Add the original url as a parameter
+    if (array_key_exists('saml:RelayState', $state)) {
+        $stateId = State::saveState(
+            $state,
+            'expirychecker:about2expire'
+        );
+      
+        $returnTo = Utilities::getUrlFromRelayState(
+            $state['saml:RelayState']
+        );
+        if (! empty($returnTo)) {
+            $passwordChangeUrl .= '?returnTo=' . $returnTo;
+        }
+    }
+
+    HTTP::redirectTrustedURL($passwordChangeUrl, array());
+}
+
+$globalConfig = Configuration::getInstance();
+
+$t = new Template($globalConfig, 'expirychecker:expired.php');
+$t->data['formTarget'] = Module::getModuleURL('expirychecker/expired.php');
+$t->data['formData'] = ['StateId' => $stateId];
+$t->data['expiresAtTimestamp'] = $state['expiresAtTimestamp'];
+$t->data['accountName'] = $state['accountName'];
+$t->show();
+
+Logger::info('expirychecker - User has been told that their password has expired.');

--- a/modules/expirychecker/www/expired.php
+++ b/modules/expirychecker/www/expired.php
@@ -5,8 +5,8 @@ use SimpleSAML\Configuration;
 use SimpleSAML\Error\BadRequest;
 use SimpleSAML\Logger;
 use SimpleSAML\Module;
-use SimpleSAML\Module\ExpiryChecker\Auth\Process\ExpiryDate;
-use SimpleSAML\Module\ExpiryChecker\Utilities;
+use SimpleSAML\Module\expirychecker\Auth\Process\ExpiryDate;
+use SimpleSAML\Module\expirychecker\Utilities;
 use SimpleSAML\Utils\HTTP;
 use SimpleSAML\XHTML\Template;
 


### PR DESCRIPTION
### Added
- Copied all pertinent code, configuration, and tests from [silinternational/simplesamlphp-module-expirychecker](https://github.com/silinternational/simplesamlphp-module-expirychecker).

### Removed
- Removed redundant test scenarios.

### Changed
- Changed the namespace on the `Validator` class to avoid a custom autoload.

--

_Note: the first [commit](https://github.com/silinternational/ssp-base/pull/193/commits/b3d3f3d3f59d7c6063838324541d8b9afbc69307) is mostly just copied files, and the remainder are the changes made to those files._