### PR TITLE
enable saml, core, and admin modules in all config files

### DIFF
--- a/development/idp-local/config/config.php
+++ b/development/idp-local/config/config.php
@@ -588,6 +588,9 @@ $config = [
      */
 
     'module.enable' => [
+        'saml' => true,
+        'core' => true,
+        'admin' => true,
         'expirychecker' => true,
         'material' => true,
         'mfa' => true,

--- a/development/idp2-local/config/config.php
+++ b/development/idp2-local/config/config.php
@@ -588,6 +588,9 @@ $config = [
      */
 
     'module.enable' => [
+        'saml' => true,
+        'core' => true,
+        'admin' => true,
         'expirychecker' => true,
         'material' => true,
         'mfa' => true,

--- a/development/idp3-local/config/config.php
+++ b/development/idp3-local/config/config.php
@@ -256,7 +256,11 @@ $config = [
      *
      */
 
-    'module.enable' => [],
+    'module.enable' => [
+        'saml' => true,
+        'core' => true,
+        'admin' => true,
+    ],
 
     /*
      * This value is the duration of the session in seconds. Make sure that the time duration of

--- a/development/sp-local/config/config.php
+++ b/development/sp-local/config/config.php
@@ -291,7 +291,11 @@ $config = [
      *
      */
 
-    'module.enable' => [],
+    'module.enable' => [
+        'saml' => true,
+        'core' => true,
+        'admin' => true,
+    ],
 
     /*
      * This value is the duration of the session in seconds. Make sure that the time duration of

--- a/development/sp2-local/config/config.php
+++ b/development/sp2-local/config/config.php
@@ -291,7 +291,11 @@ $config = [
      *
      */
 
-    'module.enable' => [],
+    'module.enable' => [
+        'saml' => true,
+        'core' => true,
+        'admin' => true,
+    ],
 
     /*
      * This value is the duration of the session in seconds. Make sure that the time duration of

--- a/development/sp3-local/config/config.php
+++ b/development/sp3-local/config/config.php
@@ -291,7 +291,11 @@ $config = [
      *
      */
 
-    'module.enable' => [],
+    'module.enable' => [
+        'saml' => true,
+        'core' => true,
+        'admin' => true,
+    ],
 
     /*
      * This value is the duration of the session in seconds. Make sure that the time duration of

--- a/dockerbuild/config/config.php
+++ b/dockerbuild/config/config.php
@@ -589,6 +589,9 @@ $config = [
      */
 
     'module.enable' => [
+        'saml' => true,
+        'core' => true,
+        'admin' => true,
         'expirychecker' => true,
         'material' => true,
         'mfa' => true,


### PR DESCRIPTION
### Changed (non-breaking)
- Add saml, core, and admin modules to the `module.enable` config entry to prepare for SimpleSAMLphp 2.x

https://itse.youtrack.cloud/issue/IDP-892