### PR TITLE
add correct types for classes inherited from SimpleSAMLphp

### DIFF
--- a/modules/expirychecker/src/Auth/Process/ExpiryDate.php
+++ b/modules/expirychecker/src/Auth/Process/ExpiryDate.php
@@ -298,11 +298,9 @@ class ExpiryDate extends ProcessingFilter
     }
     
     /**
-     * Apply this AuthProc Filter.
-     *
-     * @param array &$state The current state.
+     * @inheritDoc
      */
-    public function process(&$state): void
+    public function process(array &$state): void
     {
         $employeeId = $this->getAttribute($this->employeeIdAttr, $state);
         

--- a/modules/mfa/src/Auth/Process/Mfa.php
+++ b/modules/mfa/src/Auth/Process/Mfa.php
@@ -566,15 +566,11 @@ class Mfa extends ProcessingFilter
         
         HTTP::redirectTrustedURL($mfaSetupUrl);
     }
-    
+
     /**
-     * Apply this AuthProc Filter. It will either return (indicating that it
-     * has completed) or it will redirect the user, in which case it will
-     * later call `SimpleSAML\Auth\ProcessingChain::resumeProcessing($state)`.
-     *
-     * @param array &$state The current state.
+     * @inheritDoc
      */
-    public function process(&$state): void
+    public function process(array &$state): void
     {
         // Get the necessary info from the state data.
         $employeeId = $this->getAttribute($this->employeeIdAttr, $state);

--- a/modules/profilereview/src/Auth/Process/ProfileReview.php
+++ b/modules/profilereview/src/Auth/Process/ProfileReview.php
@@ -211,13 +211,9 @@ class ProfileReview extends ProcessingFilter
     }
 
     /**
-     * Apply this AuthProc Filter. It will either return (indicating that it
-     * has completed) or it will redirect the user, in which case it will
-     * later call `SimpleSAML\Auth\ProcessingChain::resumeProcessing($state)`.
-     *
-     * @param array &$state The current state.
+     * @inheritDoc
      */
-    public function process(&$state)
+    public function process(array &$state): void
     {
         // Get the necessary info from the state data.
         $employeeId = $this->getAttribute($this->employeeIdAttr, $state);

--- a/modules/silauth/src/Auth/Source/SilAuth.php
+++ b/modules/silauth/src/Auth/Source/SilAuth.php
@@ -59,15 +59,7 @@ class SilAuth extends UserPassBase
         ]]]);
     }
 
-    /**
-     * Initialize login.
-     *
-     * This function saves the information about the login, and redirects to a
-     * login page.
-     *
-     * @param array &$state  Information about the current authentication.
-     */
-    public function authenticate(&$state): void
+    public function authenticate(array &$state): void
     {
         assert('is_array($state)');
 
@@ -107,8 +99,8 @@ class SilAuth extends UserPassBase
         }
         return $trustedIpAddresses;
     }
-    
-    protected function login($username, $password): ?array
+
+    protected function login(string $username, string $password): array
     {
         $logger = new Psr3StdOutLogger();
         $captcha = new Captcha($this->recaptchaConfig['secret'] ?? null);

--- a/modules/silauth/src/Auth/Source/auth/Authenticator.php
+++ b/modules/silauth/src/Auth/Source/auth/Authenticator.php
@@ -213,7 +213,7 @@ class Authenticator
      *     </pre>
      * @throws \Exception
      */
-    public function getUserAttributes(): ?array
+    public function getUserAttributes(): array
     {
         if ($this->userAttributes === null) {
             throw new \Exception(

--- a/modules/silauth/src/Auth/Source/tests/unit/csrf/FakeSession.php
+++ b/modules/silauth/src/Auth/Source/tests/unit/csrf/FakeSession.php
@@ -2,35 +2,32 @@
 
 namespace SimpleSAML\Module\silauth\Auth\Source\tests\unit\csrf;
 
+use SimpleSAML\Session;
+
 /**
  * Class to mimic the bare basics of the SimpleSAML\Session class in order to
  * allow good testing of the CsrfProtector class.
  */
-class FakeSession extends \SimpleSAML\Session
+class FakeSession extends Session
 {
-    private $inMemoryDataStore;
+    private array $inMemoryDataStore;
     
-    private function __construct($transient = false)
+    private function __construct(bool $transient = false)
     {
         $this->inMemoryDataStore = [];
     }
     
-    /**
-     * @param string $type
-     * @param string|null $id
-     * @return mixed
-     */
-    public function getData($type, $id)
+    public function getData(string $type, ?string $id): mixed
     {
         return $this->inMemoryDataStore[$type][$id] ?? null;
     }
     
-    public static function getSessionFromRequest($sessionId = null)
+    public static function getSessionFromRequest(): Session
     {
         return new self();
     }
     
-    public function setData($type, $id, $data, $timeout = null)
+    public function setData(string $type, string $id, mixed $data, int|string|null $timeout = null): void
     {
         // Make sure an array exists for that type of data.
         $this->inMemoryDataStore[$type] = $this->inMemoryDataStore[$type] ?? [];

--- a/modules/sildisco/src/Auth/Process/AddIdp2NameId.php
+++ b/modules/sildisco/src/Auth/Process/AddIdp2NameId.php
@@ -110,11 +110,9 @@ class AddIdp2NameId extends \SimpleSAML\Auth\ProcessingFilter {
 
 
     /**
-     * Apply filter to copy attributes.
-     *
-     * @param array &$state  The current state array
+     * @inheritDoc
      */
-    public function process(&$state): void
+    public function process(array &$state): void
     {
         assert('is_array($state)');
 

--- a/modules/sildisco/src/Auth/Process/LogUser.php
+++ b/modules/sildisco/src/Auth/Process/LogUser.php
@@ -65,9 +65,9 @@ class LogUser extends \SimpleSAML\Auth\ProcessingFilter
     /**
      * Log info for a user's login to Dynamodb
      *
-     * @param array &$state  The current state array
+     * @inheritDoc
      */
-    public function process(&$state): void
+    public function process(array &$state): void
     {
         if (! $this->configsAreValid()) {
             return;

--- a/modules/sildisco/src/Auth/Process/TagGroup.php
+++ b/modules/sildisco/src/Auth/Process/TagGroup.php
@@ -31,9 +31,10 @@ class TagGroup extends \SimpleSAML\Auth\ProcessingFilter {
     /**
      * Apply filter to copy attributes.
      *
-     * @param array &$state  The current request
+     * @inheritDoc
      */
-    public function process(&$state) {
+    public function process(array &$state): void
+    {
         assert('is_array($request)');
         assert('array_key_exists("Attributes", $request)');
 

--- a/modules/sildisco/src/Auth/Process/TrackIdps.php
+++ b/modules/sildisco/src/Auth/Process/TrackIdps.php
@@ -11,9 +11,10 @@ class TrackIdps extends \SimpleSAML\Auth\ProcessingFilter {
     /**
      * Apply filter to save IDPs to session.
      *
-     * @param array &$request  The current request
+     * @inheritDoc
      */
-    public function process(&$request) {
+    public function process(array &$state): void
+    {
         // get the authenticating Idp and add it to the list of previous ones
         $session = \SimpleSAML\Session::getSessionFromRequest();
         $sessionDataType = "sildisco:authentication";

--- a/modules/sildisco/src/IdPDisco.php
+++ b/modules/sildisco/src/IdPDisco.php
@@ -38,13 +38,9 @@ class IdPDisco extends \SimpleSAML\XHTML\IdPDisco
 
 
     /**
-     * Log a message.
-     *
-     * This is an helper function for logging messages. It will prefix the messages with our discovery service type.
-     *
-     * @param string $message The message which should be logged.
+     * @inheritDoc
      */
-    protected function log($message): void
+    protected function log(string $message): void
     {
         \SimpleSAML\Logger::info('SildiscoIdPDisco.'.$this->instance.': '.$message);
     }
@@ -72,9 +68,7 @@ class IdPDisco extends \SimpleSAML\XHTML\IdPDisco
     }
 
     /**
-     * Handles a request to this discovery service.
-     *
-     * The IdP disco parameters should be set before calling this function.
+     * @inheritDoc
      */
     public function handleRequest(): void
     {
@@ -160,16 +154,9 @@ class IdPDisco extends \SimpleSAML\XHTML\IdPDisco
     }
 
     /**
-     * Validates the given IdP entity id.
-     *
-     * Takes a string with the IdP entity id, and returns the entity id if it is valid, or
-     * null if not. Ensures that the selected IdP is allowed for the current SP
-     *
-     * @param string|null $idp The entity id we want to validate. This can be null, in which case we will return null.
-     *
-     * @return string|null The entity id if it is valid, null if not.
+     * @inheritDoc
      */
-    protected function validateIdP($idp): ?string
+    protected function validateIdP(?string $idp): ?string
     {
         if ($idp === null) {
             return null;


### PR DESCRIPTION
### Changed (breaking)
- Updated `process` method typehinting in `Auth\ProcessingFilter` inherited classes
- Updated `login` and `authenticated` method types in `SilAuth`
- Updated `log` and `validateIdP` method types in `IdPDisco`
- Added types to `FakeSession` class inherited from `SimpleSAML\Session`

To keep this pull request relatively small in scope, tests have been skipped because they are not yet passing.

[Reference](https://simplesamlphp.org/docs/stable/simplesamlphp-upgrade-notes-2.0.html#changes-relevant-for-module-developers)

https://itse.youtrack.cloud/issue/IDP-900