### PR TITLE
SimpleSAML Utils now requires instantiation

### DIFF
--- a/development/UserPass.php
+++ b/development/UserPass.php
@@ -53,8 +53,10 @@ class UserPass extends \SimpleSAML\Module\core\Auth\UserPassBase
             $username = $userpass[0];
             $password = $userpass[1];
 
+//            $attrUtils = new \SimpleSAML\Utils\Attributes();
+//
 //            try {
-//                $attributes = \SimpleSAML\Utils\Attributes::normalizeAttributesArray($attributes);
+//                $attributes = $attrUtils->normalizeAttributesArray($attributes);
 //            } catch (\Exception $e) {
 //                throw new \Exception('Invalid attributes for user '.$username.
 //                    ' in authentication source '.$this->authId.': '.$e->getMessage());

--- a/modules/expirychecker/public/about2expire.php
+++ b/modules/expirychecker/public/about2expire.php
@@ -48,7 +48,8 @@ if (array_key_exists('changepwd', $_REQUEST)) {
         }
     }
 
-    HTTP::redirectTrustedURL($passwordChangeUrl, array());
+    $httpUtils = new HTTP();
+    $httpUtils->redirectTrustedURL($passwordChangeUrl, array());
 }
 
 $globalConfig = Configuration::getInstance();

--- a/modules/expirychecker/public/expired.php
+++ b/modules/expirychecker/public/expired.php
@@ -41,7 +41,7 @@ if (array_key_exists('changepwd', $_REQUEST)) {
         }
     }
 
-    $httpUtils = new HTTP;
+    $httpUtils = new HTTP();
     $httpUtils->redirectTrustedURL($passwordChangeUrl, array());
 }
 

--- a/modules/expirychecker/public/expired.php
+++ b/modules/expirychecker/public/expired.php
@@ -41,7 +41,8 @@ if (array_key_exists('changepwd', $_REQUEST)) {
         }
     }
 
-    HTTP::redirectTrustedURL($passwordChangeUrl, array());
+    $httpUtils = new HTTP;
+    $httpUtils->redirectTrustedURL($passwordChangeUrl, array());
 }
 
 $globalConfig = Configuration::getInstance();

--- a/modules/expirychecker/src/Auth/Process/ExpiryDate.php
+++ b/modules/expirychecker/src/Auth/Process/ExpiryDate.php
@@ -294,7 +294,7 @@ class ExpiryDate extends ProcessingFilter
             'passwordChangeUrl' => $passwordChangeUrl,
         ]));
 
-        $httpUtils = new HTTP;
+        $httpUtils = new HTTP();
         $httpUtils->redirectTrustedURL($passwordChangeUrl, array());
     }
     
@@ -368,7 +368,7 @@ class ExpiryDate extends ProcessingFilter
         $id = State::saveState($state, 'expirychecker:expired');
         $url = Module::getModuleURL('expirychecker/expired.php');
 
-        $httpUtils = new HTTP;
+        $httpUtils = new HTTP();
         $httpUtils->redirectTrustedURL($url, array('StateId' => $id));
     }
     
@@ -405,7 +405,7 @@ class ExpiryDate extends ProcessingFilter
         $id = State::saveState($state, 'expirychecker:about2expire');
         $url = Module::getModuleURL('expirychecker/about2expire.php');
 
-        $httpUtils = new HTTP;
+        $httpUtils = new HTTP();
         $httpUtils->redirectTrustedURL($url, array('StateId' => $id));
     }
 }

--- a/modules/expirychecker/src/Auth/Process/ExpiryDate.php
+++ b/modules/expirychecker/src/Auth/Process/ExpiryDate.php
@@ -294,7 +294,8 @@ class ExpiryDate extends ProcessingFilter
             'passwordChangeUrl' => $passwordChangeUrl,
         ]));
 
-        HTTP::redirectTrustedURL($passwordChangeUrl, array());
+        $httpUtils = new HTTP;
+        $httpUtils->redirectTrustedURL($passwordChangeUrl, array());
     }
     
     /**
@@ -367,7 +368,8 @@ class ExpiryDate extends ProcessingFilter
         $id = State::saveState($state, 'expirychecker:expired');
         $url = Module::getModuleURL('expirychecker/expired.php');
 
-        HTTP::redirectTrustedURL($url, array('StateId' => $id));
+        $httpUtils = new HTTP;
+        $httpUtils->redirectTrustedURL($url, array('StateId' => $id));
     }
     
     /**
@@ -403,6 +405,7 @@ class ExpiryDate extends ProcessingFilter
         $id = State::saveState($state, 'expirychecker:about2expire');
         $url = Module::getModuleURL('expirychecker/about2expire.php');
 
-        HTTP::redirectTrustedURL($url, array('StateId' => $id));
+        $httpUtils = new HTTP;
+        $httpUtils->redirectTrustedURL($url, array('StateId' => $id));
     }
 }

--- a/modules/mfa/public/prompt-for-mfa.php
+++ b/modules/mfa/public/prompt-for-mfa.php
@@ -60,7 +60,8 @@ if (empty($mfaId)) {
         'mfaId' => $mfaOption['id'],
         'StateId' => $stateId,
     ]);
-    HTTP::redirectTrustedURL($moduleUrl);
+    $httpUtils = new HTTP;
+    $httpUtils->redirectTrustedURL($moduleUrl);
     return;
 }
 $mfaOption = Mfa::getMfaOptionById($mfaOptions, $mfaId);

--- a/modules/mfa/public/prompt-for-mfa.php
+++ b/modules/mfa/public/prompt-for-mfa.php
@@ -60,7 +60,7 @@ if (empty($mfaId)) {
         'mfaId' => $mfaOption['id'],
         'StateId' => $stateId,
     ]);
-    $httpUtils = new HTTP;
+    $httpUtils = new HTTP();
     $httpUtils->redirectTrustedURL($moduleUrl);
     return;
 }

--- a/modules/mfa/public/send-manager-mfa.php
+++ b/modules/mfa/public/send-manager-mfa.php
@@ -29,7 +29,7 @@ if (filter_has_var(INPUT_POST, 'send')) {
     $moduleUrl = SimpleSAML\Module::getModuleURL('mfa/prompt-for-mfa.php', [
         'StateId' => $stateId,
     ]);
-    $httpUtils = new HTTP;
+    $httpUtils = new HTTP();
     $httpUtils->redirectTrustedURL($moduleUrl);
 }
 

--- a/modules/mfa/public/send-manager-mfa.php
+++ b/modules/mfa/public/send-manager-mfa.php
@@ -29,7 +29,8 @@ if (filter_has_var(INPUT_POST, 'send')) {
     $moduleUrl = SimpleSAML\Module::getModuleURL('mfa/prompt-for-mfa.php', [
         'StateId' => $stateId,
     ]);
-    HTTP::redirectTrustedURL($moduleUrl);
+    $httpUtils = new HTTP;
+    $httpUtils->redirectTrustedURL($moduleUrl);
 }
 
 $globalConfig = Configuration::getInstance();

--- a/modules/mfa/src/Auth/Process/Mfa.php
+++ b/modules/mfa/src/Auth/Process/Mfa.php
@@ -373,7 +373,7 @@ class Mfa extends ProcessingFilter
         $stateId = State::saveState($state, self::STAGE_SENT_TO_NEW_BACKUP_CODES_PAGE);
         $url = Module::getModuleURL('mfa/new-backup-codes.php');
         
-        $httpUtils = new HTTP;
+        $httpUtils = new HTTP();
         $httpUtils->redirectTrustedURL($url, ['StateId' => $stateId]);
     }
     
@@ -549,7 +549,7 @@ class Mfa extends ProcessingFilter
     {
         $mfaSetupUrl = $state['mfaSetupUrl'];
 
-        $httpUtils = new HTTP;
+        $httpUtils = new HTTP();
 
         // Tell the MFA-setup URL where the user is ultimately trying to go (if known).
         $currentDestination = self::getRelayStateUrl($state);
@@ -637,7 +637,7 @@ class Mfa extends ProcessingFilter
         $stateId = State::saveState($state, self::STAGE_SENT_TO_MFA_NEEDED_MESSAGE);
         $url = Module::getModuleURL('mfa/must-set-up-mfa.php');
         
-        $httpUtils = new HTTP;
+        $httpUtils = new HTTP();
         $httpUtils->redirectTrustedURL($url, ['StateId' => $stateId]);
     }
 
@@ -687,7 +687,7 @@ class Mfa extends ProcessingFilter
 
         $mfaOption = self::getMfaOptionToUse($mfaOptions, $userAgent);
         
-        $httpUtils = new HTTP;
+        $httpUtils = new HTTP();
         $httpUtils->redirectTrustedURL($url, [
             'mfaId' => $mfaOption['id'],
             'StateId' => $id,
@@ -768,7 +768,7 @@ class Mfa extends ProcessingFilter
         $stateId = State::saveState($state, self::STAGE_SENT_TO_LOW_ON_BACKUP_CODES_NAG);
         $url = Module::getModuleURL('mfa/low-on-backup-codes.php');
         
-        $httpUtils = new HTTP;
+        $httpUtils = new HTTP();
         $httpUtils->redirectTrustedURL($url, ['StateId' => $stateId]);
     }
     
@@ -788,7 +788,7 @@ class Mfa extends ProcessingFilter
         $stateId = State::saveState($state, self::STAGE_SENT_TO_OUT_OF_BACKUP_CODES_MESSAGE);
         $url = Module::getModuleURL('mfa/out-of-backup-codes.php');
         
-        $httpUtils = new HTTP;
+        $httpUtils = new HTTP();
         $httpUtils->redirectTrustedURL($url, ['StateId' => $stateId]);
     }
 
@@ -860,7 +860,7 @@ class Mfa extends ProcessingFilter
 
         $url = Module::getModuleURL('mfa/prompt-for-mfa.php');
 
-        $httpUtils = new HTTP;
+        $httpUtils = new HTTP();
         $httpUtils->redirectTrustedURL($url, ['mfaId' => $mfaOption['id'], 'StateId' => $stateId]);
     }
 

--- a/modules/mfa/src/Auth/Process/Mfa.php
+++ b/modules/mfa/src/Auth/Process/Mfa.php
@@ -373,7 +373,8 @@ class Mfa extends ProcessingFilter
         $stateId = State::saveState($state, self::STAGE_SENT_TO_NEW_BACKUP_CODES_PAGE);
         $url = Module::getModuleURL('mfa/new-backup-codes.php');
         
-        HTTP::redirectTrustedURL($url, ['StateId' => $stateId]);
+        $httpUtils = new HTTP;
+        $httpUtils->redirectTrustedURL($url, ['StateId' => $stateId]);
     }
     
     protected static function hasMfaOptions(array $mfa): bool
@@ -547,11 +548,13 @@ class Mfa extends ProcessingFilter
     public static function redirectToMfaSetup(array &$state): void
     {
         $mfaSetupUrl = $state['mfaSetupUrl'];
-        
+
+        $httpUtils = new HTTP;
+
         // Tell the MFA-setup URL where the user is ultimately trying to go (if known).
         $currentDestination = self::getRelayStateUrl($state);
         if (! empty($currentDestination)) {
-            $mfaSetupUrl = HTTP::addURLParameters(
+            $mfaSetupUrl = $httpUtils->addURLParameters(
                 $mfaSetupUrl,
                 ['returnTo' => $currentDestination]
             );
@@ -564,7 +567,7 @@ class Mfa extends ProcessingFilter
             var_export($mfaSetupUrl, true)
         ));
         
-        HTTP::redirectTrustedURL($mfaSetupUrl);
+        $httpUtils->redirectTrustedURL($mfaSetupUrl);
     }
 
     /**
@@ -634,7 +637,8 @@ class Mfa extends ProcessingFilter
         $stateId = State::saveState($state, self::STAGE_SENT_TO_MFA_NEEDED_MESSAGE);
         $url = Module::getModuleURL('mfa/must-set-up-mfa.php');
         
-        HTTP::redirectTrustedURL($url, ['StateId' => $stateId]);
+        $httpUtils = new HTTP;
+        $httpUtils->redirectTrustedURL($url, ['StateId' => $stateId]);
     }
 
     /**
@@ -683,7 +687,8 @@ class Mfa extends ProcessingFilter
 
         $mfaOption = self::getMfaOptionToUse($mfaOptions, $userAgent);
         
-        HTTP::redirectTrustedURL($url, [
+        $httpUtils = new HTTP;
+        $httpUtils->redirectTrustedURL($url, [
             'mfaId' => $mfaOption['id'],
             'StateId' => $id,
         ]);
@@ -763,7 +768,8 @@ class Mfa extends ProcessingFilter
         $stateId = State::saveState($state, self::STAGE_SENT_TO_LOW_ON_BACKUP_CODES_NAG);
         $url = Module::getModuleURL('mfa/low-on-backup-codes.php');
         
-        HTTP::redirectTrustedURL($url, ['StateId' => $stateId]);
+        $httpUtils = new HTTP;
+        $httpUtils->redirectTrustedURL($url, ['StateId' => $stateId]);
     }
     
     /**
@@ -782,7 +788,8 @@ class Mfa extends ProcessingFilter
         $stateId = State::saveState($state, self::STAGE_SENT_TO_OUT_OF_BACKUP_CODES_MESSAGE);
         $url = Module::getModuleURL('mfa/out-of-backup-codes.php');
         
-        HTTP::redirectTrustedURL($url, ['StateId' => $stateId]);
+        $httpUtils = new HTTP;
+        $httpUtils->redirectTrustedURL($url, ['StateId' => $stateId]);
     }
 
     /**
@@ -853,7 +860,8 @@ class Mfa extends ProcessingFilter
 
         $url = Module::getModuleURL('mfa/prompt-for-mfa.php');
 
-        HTTP::redirectTrustedURL($url, ['mfaId' => $mfaOption['id'], 'StateId' => $stateId]);
+        $httpUtils = new HTTP;
+        $httpUtils->redirectTrustedURL($url, ['mfaId' => $mfaOption['id'], 'StateId' => $stateId]);
     }
 
     /**

--- a/modules/profilereview/src/Auth/Process/ProfileReview.php
+++ b/modules/profilereview/src/Auth/Process/ProfileReview.php
@@ -192,8 +192,9 @@ class ProfileReview extends ProcessingFilter
         $profileUrl = $state['ProfileUrl'];
         // Tell the profile-setup URL where the user is ultimately trying to go (if known).
         $currentDestination = self::getRelayStateUrl($state);
+        $httpUtils = new HTTP;
         if (! empty($currentDestination)) {
-            $profileUrl = HTTP::addURLParameters(
+            $profileUrl = $httpUtils->addURLParameters(
                 $profileUrl,
                 ['returnTo' => $currentDestination]
             );
@@ -207,7 +208,7 @@ class ProfileReview extends ProcessingFilter
             'profileUrl' => $profileUrl,
         ]));
 
-        HTTP::redirectTrustedURL($profileUrl);
+        $httpUtils->redirectTrustedURL($profileUrl);
     }
 
     /**
@@ -290,7 +291,8 @@ class ProfileReview extends ProcessingFilter
         $stateId = State::saveState($state, self::STAGE_SENT_TO_NAG);
         $url = Module::getModuleURL('profilereview/nag.php');
 
-        HTTP::redirectTrustedURL($url, array('StateId' => $stateId));
+        $httpUtils = new HTTP;
+        $httpUtils->redirectTrustedURL($url, array('StateId' => $stateId));
     }
 
     /**
@@ -309,7 +311,8 @@ class ProfileReview extends ProcessingFilter
         $stateId = State::saveState($state, self::STAGE_SENT_TO_NAG);
         $url = Module::getModuleURL('profilereview/nag.php');
 
-        HTTP::redirectTrustedURL($url, array('StateId' => $stateId));
+        $httpUtils = new HTTP;
+        $httpUtils->redirectTrustedURL($url, array('StateId' => $stateId));
     }
 
     public static function hasSeenSplashPageRecently(string $page)

--- a/modules/profilereview/src/Auth/Process/ProfileReview.php
+++ b/modules/profilereview/src/Auth/Process/ProfileReview.php
@@ -192,7 +192,7 @@ class ProfileReview extends ProcessingFilter
         $profileUrl = $state['ProfileUrl'];
         // Tell the profile-setup URL where the user is ultimately trying to go (if known).
         $currentDestination = self::getRelayStateUrl($state);
-        $httpUtils = new HTTP;
+        $httpUtils = new HTTP();
         if (! empty($currentDestination)) {
             $profileUrl = $httpUtils->addURLParameters(
                 $profileUrl,
@@ -291,7 +291,7 @@ class ProfileReview extends ProcessingFilter
         $stateId = State::saveState($state, self::STAGE_SENT_TO_NAG);
         $url = Module::getModuleURL('profilereview/nag.php');
 
-        $httpUtils = new HTTP;
+        $httpUtils = new HTTP();
         $httpUtils->redirectTrustedURL($url, array('StateId' => $stateId));
     }
 
@@ -311,7 +311,7 @@ class ProfileReview extends ProcessingFilter
         $stateId = State::saveState($state, self::STAGE_SENT_TO_NAG);
         $url = Module::getModuleURL('profilereview/nag.php');
 
-        $httpUtils = new HTTP;
+        $httpUtils = new HTTP();
         $httpUtils->redirectTrustedURL($url, array('StateId' => $stateId));
     }
 

--- a/modules/silauth/src/Auth/Source/SilAuth.php
+++ b/modules/silauth/src/Auth/Source/SilAuth.php
@@ -81,7 +81,7 @@ class SilAuth extends UserPassBase
          */
         $url = Module::getModuleURL('silauth/loginuserpass.php');
         $params = array('AuthState' => $id);
-        $httpUtils = new HTTP;
+        $httpUtils = new HTTP();
         $httpUtils->redirectTrustedURL($url, $params);
 
         /* The previous function never returns, so this code is never executed. */

--- a/modules/silauth/src/Auth/Source/SilAuth.php
+++ b/modules/silauth/src/Auth/Source/SilAuth.php
@@ -81,7 +81,8 @@ class SilAuth extends UserPassBase
          */
         $url = Module::getModuleURL('silauth/loginuserpass.php');
         $params = array('AuthState' => $id);
-        HTTP::redirectTrustedURL($url, $params);
+        $httpUtils = new HTTP;
+        $httpUtils->redirectTrustedURL($url, $params);
 
         /* The previous function never returns, so this code is never executed. */
         assert('FALSE');

--- a/modules/sildisco/public/metadata.php
+++ b/modules/sildisco/public/metadata.php
@@ -20,7 +20,7 @@ if (!$config->getBoolean('enable.saml20-idp', false)) {
 }
 
 // check if valid local session exists
-//$authUtils = new Auth;
+//$authUtils = new Auth();
 //if ($config->getBoolean('admin.protectmetadata', false)) {
 //    $authUtils->requireAdmin();
 //}
@@ -33,7 +33,7 @@ try {
 
     $availableCerts = array();
 
-    $cryptoUtils = new Crypto;
+    $cryptoUtils = new Crypto();
 
     $keys = array();
     $certInfo = $cryptoUtils->loadPublicKey($idpmeta, false, 'new_');
@@ -115,7 +115,7 @@ try {
         $metaArray['keys'] = $keys;
     }
 
-    $httpUtils = new HTTP;
+    $httpUtils = new HTTP();
 
     if ($idpmeta->getBoolean('saml20.sendartifact', false)) {
         // Artifact sending enabled

--- a/modules/sildisco/public/metadata.php
+++ b/modules/sildisco/public/metadata.php
@@ -20,8 +20,9 @@ if (!$config->getBoolean('enable.saml20-idp', false)) {
 }
 
 // check if valid local session exists
+//$authUtils = new Auth;
 //if ($config->getBoolean('admin.protectmetadata', false)) {
-//    Auth::requireAdmin();
+//    $authUtils->requireAdmin();
 //}
 
 try {
@@ -32,8 +33,10 @@ try {
 
     $availableCerts = array();
 
+    $cryptoUtils = new Crypto;
+
     $keys = array();
-    $certInfo = Crypto::loadPublicKey($idpmeta, false, 'new_');
+    $certInfo = $cryptoUtils->loadPublicKey($idpmeta, false, 'new_');
     if ($certInfo !== null) {
         $availableCerts['new_idp.crt'] = $certInfo;
         $keys[] = array(
@@ -47,7 +50,7 @@ try {
         $hasNewCert = false;
     }
 
-    $certInfo = Crypto::loadPublicKey($idpmeta, true);
+    $certInfo = $cryptoUtils->loadPublicKey($idpmeta, true);
     $availableCerts['idp.crt'] = $certInfo;
     $keys[] = array(
         'type'            => 'X509Certificate',
@@ -57,7 +60,7 @@ try {
     );
 
     if ($idpmeta->hasValue('https.certificate')) {
-        $httpsCert = Crypto::loadPublicKey($idpmeta, true, 'https.');
+        $httpsCert = $cryptoUtils->loadPublicKey($idpmeta, true, 'https.');
         assert('isset($httpsCert["certData"])');
         $availableCerts['https.crt'] = $httpsCert;
         $keys[] = array(
@@ -112,11 +115,13 @@ try {
         $metaArray['keys'] = $keys;
     }
 
+    $httpUtils = new HTTP;
+
     if ($idpmeta->getBoolean('saml20.sendartifact', false)) {
         // Artifact sending enabled
         $metaArray['ArtifactResolutionService'][] = array(
             'index'    => 0,
-            'Location' => HTTP::getBaseURL().'saml2/idp/ArtifactResolutionService.php',
+            'Location' => $httpUtils->getBaseURL().'saml2/idp/ArtifactResolutionService.php',
             'Binding'  => Constants::BINDING_SOAP,
         );
     }
@@ -126,7 +131,7 @@ try {
         array_unshift($metaArray['SingleSignOnService'], array(
             'hoksso:ProtocolBinding' => Constants::BINDING_HTTP_REDIRECT,
             'Binding'                => Constants::BINDING_HOK_SSO,
-            'Location'               => HTTP::getBaseURL().'saml2/idp/SSOService.php'
+            'Location'               => $httpUtils->getBaseURL().'saml2/idp/SSOService.php'
         ));
     }
 

--- a/modules/sildisco/src/IdPDisco.php
+++ b/modules/sildisco/src/IdPDisco.php
@@ -5,6 +5,8 @@ namespace SimpleSAML\Module\sildisco;
 use Sil\SspUtils\AnnouncementUtils;
 use Sil\SspUtils\DiscoUtils;
 use Sil\SspUtils\Metadata;
+use SimpleSAML\Utils\Arrays;
+use SimpleSAML\Utils\HTTP;
 
 /**
  * This class implements a custom IdP discovery service, for use with a ssp hub (proxy)
@@ -76,6 +78,8 @@ class IdPDisco extends \SimpleSAML\XHTML\IdPDisco
         $this->start();
         list($spEntityId, $idpList) = $this->getSPEntityIDAndReducedIdpList();
 
+        $httpUtils = new HTTP;
+
         if (sizeof($idpList) == 1) {
             $idp = array_keys($idpList)[0];
             $idp = $this->validateIdP($idp);
@@ -86,7 +90,7 @@ class IdPDisco extends \SimpleSAML\XHTML\IdPDisco
                     $this->returnIdParam . ')'
                 );
 
-                \SimpleSAML\Utils\HTTP::redirectTrustedURL(
+                $httpUtils->redirectTrustedURL(
                     $this->returnURL,
                     array($this->returnIdParam => $idp)
                 );
@@ -102,8 +106,9 @@ class IdPDisco extends \SimpleSAML\XHTML\IdPDisco
 
         $rawSPName = $spEntries[$spEntityId][self::$spNameMdKey] ?? null;
         if ($rawSPName !== null) {
+            $arrayUtils = new Arrays;
             $spName = htmlspecialchars($t->getTranslator()->getPreferredTranslation(
-                \SimpleSAML\Utils\Arrays::arrayize($rawSPName, 'en')
+                $arrayUtils->arrayize($rawSPName, 'en')
             ))   ;
         }
 
@@ -112,7 +117,7 @@ class IdPDisco extends \SimpleSAML\XHTML\IdPDisco
         $t->data['returnIDParam'] = $this->returnIdParam;
         $t->data['entityID'] = $this->spEntityId;
         $t->data['spName'] = $spName;
-        $t->data['urlpattern'] = htmlspecialchars(\SimpleSAML\Utils\HTTP::getSelfURLNoQuery());
+        $t->data['urlpattern'] = htmlspecialchars($httpUtils->getSelfURLNoQuery());
         $t->data['announcement'] = AnnouncementUtils::getAnnouncement();
         $t->data['helpCenterUrl'] = $this->config->getValue('helpCenterUrl', '');
 

--- a/modules/sildisco/src/IdPDisco.php
+++ b/modules/sildisco/src/IdPDisco.php
@@ -78,7 +78,7 @@ class IdPDisco extends \SimpleSAML\XHTML\IdPDisco
         $this->start();
         list($spEntityId, $idpList) = $this->getSPEntityIDAndReducedIdpList();
 
-        $httpUtils = new HTTP;
+        $httpUtils = new HTTP();
 
         if (sizeof($idpList) == 1) {
             $idp = array_keys($idpList)[0];
@@ -106,7 +106,7 @@ class IdPDisco extends \SimpleSAML\XHTML\IdPDisco
 
         $rawSPName = $spEntries[$spEntityId][self::$spNameMdKey] ?? null;
         if ($rawSPName !== null) {
-            $arrayUtils = new Arrays;
+            $arrayUtils = new Arrays();
             $spName = htmlspecialchars($t->getTranslator()->getPreferredTranslation(
                 $arrayUtils->arrayize($rawSPName, 'en')
             ))   ;


### PR DESCRIPTION
### Changed
- The SimpleSAML\Utils classes now require instantiation to call member functions because the methods are no longer static.

https://itse.youtrack.cloud/issue/IDP-1103