### PR TITLE
change getString to getOptionalString where a default is provided

### DIFF
--- a/modules/silauth/src/Auth/Source/system/System.php
+++ b/modules/silauth/src/Auth/Source/system/System.php
@@ -4,10 +4,8 @@ namespace SimpleSAML\Module\silauth\Auth\Source\system;
 
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use SimpleSAML\Module\silauth\Auth\Source\auth\IdBroker;
-use SimpleSAML\Module\silauth\Auth\Source\config\ConfigManager;
+use SimpleSAML\Configuration;
 use SimpleSAML\Module\silauth\Auth\Source\models\FailedLoginIpAddress;
-use \SimpleSAML\Configuration;
 use Throwable;
 
 class System
@@ -46,7 +44,7 @@ class System
          *       HTTP_HOST value (provided by the user's request) is used to
          *       build a trusted URL (see SimpleSaml\Module::authenticate()).
          */
-        $baseURL = $globalConfig->getString('baseurlpath', '');
+        $baseURL = $globalConfig->getOptionalString('baseurlpath', '');
         $avoidsSecurityHole = (preg_match('#^https?://.*/$#D', $baseURL) === 1);
         if (!$avoidsSecurityHole) {
             $this->logError('isRequiredConfigPresent failed: baseurlpath (' . $baseURL . ') does not meet requirements');

--- a/modules/sildisco/public/metadata.php
+++ b/modules/sildisco/public/metadata.php
@@ -14,13 +14,13 @@ use SimpleSAML\Utils\HTTP as HTTP;
 $config = \SimpleSAML\Configuration::getInstance();
 $metadata = \SimpleSAML\Metadata\MetaDataStorageHandler::getMetadataHandler();
 
-if (!$config->getBoolean('enable.saml20-idp', false)) {
+if (!$config->getOptionalBoolean('enable.saml20-idp', false)) {
     throw new \SimpleSAML\Error\Error('NOACCESS');
 }
 
 // check if valid local session exists
 //$authUtils = new Auth();
-//if ($config->getBoolean('admin.protectmetadata', false)) {
+//if ($config->getOptionalBoolean('admin.protectmetadata', false)) {
 //    $authUtils->requireAdmin();
 //}
 
@@ -116,7 +116,7 @@ try {
 
     $httpUtils = new HTTP();
 
-    if ($idpmeta->getBoolean('saml20.sendartifact', false)) {
+    if ($idpmeta->getOptionalBoolean('saml20.sendartifact', false)) {
         // Artifact sending enabled
         $metaArray['ArtifactResolutionService'][] = array(
             'index' => 0,
@@ -125,7 +125,7 @@ try {
         );
     }
 
-    if ($idpmeta->getBoolean('saml20.hok.assertion', false)) {
+    if ($idpmeta->getOptionalBoolean('saml20.hok.assertion', false)) {
         // Prepend HoK SSO Service endpoint.
         array_unshift($metaArray['SingleSignOnService'], array(
             'hoksso:ProtocolBinding' => Constants::BINDING_HTTP_REDIRECT,

--- a/modules/sildisco/public/metadata.php
+++ b/modules/sildisco/public/metadata.php
@@ -192,8 +192,8 @@ try {
         }
     }
 
-    $technicalContactEmail = $config->getOptionalString('technicalcontact_email', false);
-    if ($technicalContactEmail && $technicalContactEmail !== 'na@example.org') {
+    $technicalContactEmail = $config->getOptionalString('technicalcontact_email', null);
+    if (!empty($technicalContactEmail) && $technicalContactEmail !== 'na@example.org') {
         $techcontact['emailAddress'] = $technicalContactEmail;
         $techcontact['name'] = $config->getOptionalString('technicalcontact_name', null);
         $techcontact['contactType'] = 'technical';

--- a/modules/sildisco/public/metadata.php
+++ b/modules/sildisco/public/metadata.php
@@ -6,10 +6,9 @@
 require_once('../public/_include.php');
 
 use SAML2\Constants;
-use SimpleSAML\Utils\Auth as Auth;
+use SimpleSAML\Utils\Config\Metadata as Metadata;
 use SimpleSAML\Utils\Crypto as Crypto;
 use SimpleSAML\Utils\HTTP as HTTP;
-use SimpleSAML\Utils\Config\Metadata as Metadata;
 
 // load SimpleSAMLphp, configuration and metadata
 $config = \SimpleSAML\Configuration::getInstance();
@@ -135,7 +134,7 @@ try {
         ));
     }
 
-    $metaArray['NameIDFormat'] = $idpmeta->getString(
+    $metaArray['NameIDFormat'] = $idpmeta->getOptionalString(
         'NameIDFormat',
         'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
     );
@@ -193,10 +192,10 @@ try {
         }
     }
 
-    $technicalContactEmail = $config->getString('technicalcontact_email', false);
+    $technicalContactEmail = $config->getOptionalString('technicalcontact_email', false);
     if ($technicalContactEmail && $technicalContactEmail !== 'na@example.org') {
         $techcontact['emailAddress'] = $technicalContactEmail;
-        $techcontact['name'] = $config->getString('technicalcontact_name', null);
+        $techcontact['name'] = $config->getOptionalString('technicalcontact_name', null);
         $techcontact['contactType'] = 'technical';
         $metaArray['contacts'][] = Metadata::getContact($techcontact);
     }

--- a/modules/sildisco/src/IdPDisco.php
+++ b/modules/sildisco/src/IdPDisco.php
@@ -134,7 +134,7 @@ class IdPDisco extends \SimpleSAML\XHTML\IdPDisco
         $t->data['spName'] = $spName;
         $t->data['urlpattern'] = htmlspecialchars($httpUtils->getSelfURLNoQuery());
         $t->data['announcement'] = AnnouncementUtils::getAnnouncement();
-        $t->data['helpCenterUrl'] = $this->config->getValue('helpCenterUrl', '');
+        $t->data['helpCenterUrl'] = $this->config->getOptionalString('helpCenterUrl', '');
 
         $t->show();
     }

--- a/modules/sildisco/src/IdPDisco.php
+++ b/modules/sildisco/src/IdPDisco.php
@@ -181,7 +181,7 @@ class IdPDisco extends \SimpleSAML\XHTML\IdPDisco
         if ($idp === null) {
             return null;
         }
-        if (!$this->config->getBoolean('idpdisco.validate', true)) {
+        if (!$this->config->getOptionalBoolean('idpdisco.validate', true)) {
             return $idp;
         }
 

--- a/modules/sildisco/src/SSOService.php
+++ b/modules/sildisco/src/SSOService.php
@@ -32,7 +32,7 @@ $hubModeKey = 'hubmode';
 
 try {
 // If in hub mode, then use the sildisco entry script
-    if ($config->getValue($hubModeKey, false)) {
+    if ($config->getOptionalBoolean($hubModeKey, false)) {
         \SimpleSAML\Module\sildisco\IdP\SAML2::receiveAuthnRequest($idp);
     } else {
         \SimpleSAML\Module\saml\IdP\SAML2::receiveAuthnRequest($idp);


### PR DESCRIPTION
### Changed
- Change `getString` calls to `getOptionalString` where a default value is given. The signature of `getString` changed in SimpleSAMLphp 2.0, removing the second parameter.
- Change `getBoolean` calls to `getOptionalBoolean` where a default value is given. The signature of `getBoolean` changed in SimpleSAMLphp 2.0, removing the second parameter.
- Change `getValue` calls to type-specific methods

[Reference](https://simplesamlphp.org/docs/stable/simplesamlphp-upgrade-notes-2.0.html#changes-relevant-for-module-developers)