### PR TITLE
instantiate SimpleSAML\Utils classes

### DIFF
--- a/modules/sildisco/public/metadata.php
+++ b/modules/sildisco/public/metadata.php
@@ -6,10 +6,7 @@
 require_once('../public/_include.php');
 
 use SAML2\Constants;
-use SimpleSAML\Utils\Auth as Auth;
-use SimpleSAML\Utils\Crypto as Crypto;
-use SimpleSAML\Utils\HTTP as HTTP;
-use SimpleSAML\Utils\Config\Metadata as Metadata;
+use SimpleSAML\Utils;
 
 // load SimpleSAMLphp, configuration and metadata
 $config = \SimpleSAML\Configuration::getInstance();
@@ -20,8 +17,8 @@ if (!$config->getBoolean('enable.saml20-idp', false)) {
 }
 
 // check if valid local session exists
-//$authUtils = new Auth();
-//if ($config->getBoolean('admin.protectmetadata', false)) {
+//$authUtils = new Utils\Auth();
+//if ($config->getOptionalBoolean('admin.protectmetadata', false)) {
 //    $authUtils->requireAdmin();
 //}
 
@@ -33,7 +30,7 @@ try {
 
     $availableCerts = array();
 
-    $cryptoUtils = new Crypto();
+    $cryptoUtils = new Utils\Crypto();
 
     $keys = array();
     $certInfo = $cryptoUtils->loadPublicKey($idpmeta, false, 'new_');
@@ -115,7 +112,7 @@ try {
         $metaArray['keys'] = $keys;
     }
 
-    $httpUtils = new HTTP();
+    $httpUtils = new Utils\HTTP();
 
     if ($idpmeta->getBoolean('saml20.sendartifact', false)) {
         // Artifact sending enabled
@@ -157,11 +154,13 @@ try {
         $metaArray['scope'] = $idpmeta->getArray('scope');
     }
 
+    $metadataUtils = Utils\Metadata();
+
     if ($idpmeta->hasValue('EntityAttributes')) {
         $metaArray['EntityAttributes'] = $idpmeta->getArray('EntityAttributes');
 
         // check for entity categories
-        if (Metadata::isHiddenFromDiscovery($metaArray)) {
+        if ($metadataUtils->isHiddenFromDiscovery($metaArray)) {
             $metaArray['hide.from.discovery'] = true;
         }
     }
@@ -189,7 +188,7 @@ try {
     if ($idpmeta->hasValue('contacts')) {
         $contacts = $idpmeta->getArray('contacts');
         foreach ($contacts as $contact) {
-            $metaArray['contacts'][] = Metadata::getContact($contact);
+            $metaArray['contacts'][] = $metadataUtils->getContact($contact);
         }
     }
 
@@ -198,7 +197,7 @@ try {
         $techcontact['emailAddress'] = $technicalContactEmail;
         $techcontact['name'] = $config->getString('technicalcontact_name', null);
         $techcontact['contactType'] = 'technical';
-        $metaArray['contacts'][] = Metadata::getContact($techcontact);
+        $metaArray['contacts'][] = $metadataUtils->getContact($techcontact);
     }
 
     $metaBuilder = new \SimpleSAML\Metadata\SAMLBuilder($idpentityid);

--- a/modules/sildisco/public/sp/saml2-logout.php
+++ b/modules/sildisco/public/sp/saml2-logout.php
@@ -58,8 +58,9 @@ $spMetadata = $source->getMetadata();
 
 \SimpleSAML\Module\saml\Message::validateMessage($idpMetadata, $spMetadata, $message);
 
+$httpUtils = new \SimpleSAML\Utils\HTTP();
 $destination = $message->getDestination();
-if ($destination !== null && $destination !== \SimpleSAML\Utils\HTTP::getSelfURLNoQuery()) {
+if ($destination !== null && $destination !== $httpUtils->getSelfURLNoQuery()) {
     throw new \SimpleSAML\Error\Exception('Destination in logout message is wrong.');
 }
 


### PR DESCRIPTION
### Changed
- Instantiate SimpleSAML\Utils classes. In SimpleSAMLphp 2, the Utils class methods have been made non-static.

https://itse.youtrack.cloud/issue/IDP-1103

[Reference](https://simplesamlphp.org/docs/stable/simplesamlphp-upgrade-notes-2.0.html#changes-relevant-for-module-developers)