### PR TITLE
define variables needed in the header template

### DIFF
--- a/modules/expirychecker/public/about2expire.php
+++ b/modules/expirychecker/public/about2expire.php
@@ -55,6 +55,8 @@ if (array_key_exists('changepwd', $_REQUEST)) {
 $globalConfig = Configuration::getInstance();
 
 $t = new Template($globalConfig, 'expirychecker:about2expire');
+$t->data['theme_color_scheme'] = $globalConfig->getOptionalString('theme.color-scheme', '');
+$t->data['analytics_tracking_id'] = $globalConfig->getOptionalString('analytics.trackingId', '');
 $t->data['form_target'] = Module::getModuleURL('expirychecker/about2expire.php');
 $t->data['form_data'] = ['StateId' => $stateId];
 $t->data['days_left'] = $state['daysLeft'];

--- a/modules/expirychecker/public/expired.php
+++ b/modules/expirychecker/public/expired.php
@@ -48,6 +48,8 @@ if (array_key_exists('changepwd', $_REQUEST)) {
 $globalConfig = Configuration::getInstance();
 
 $t = new Template($globalConfig, 'expirychecker:expired');
+$t->data['theme_color_scheme'] = $globalConfig->getOptionalString('theme.color-scheme', '');
+$t->data['analytics_tracking_id'] = $globalConfig->getOptionalString('analytics.trackingId', '');
 $t->data['form_target'] = Module::getModuleURL('expirychecker/expired.php');
 $t->data['form_data'] = ['StateId' => $stateId];
 $t->send();

--- a/modules/material/themes/material/default/header.twig
+++ b/modules/material/themes/material/default/header.twig
@@ -5,9 +5,9 @@
 
 <base href="{{ baseurlpath }}/module.php/material/">
 
-{% if analyticsTrackingId is defined and analyticsTrackingId is not empty %}
+{% if analytics_tracking_id is not empty %}
   <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id={{ analyticsTrackingId }}"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id={{ analytics_tracking_id }}"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
 
@@ -17,12 +17,11 @@
 
     gtag('js', new Date());
 
-    gtag('config', '{{ analyticsTrackingId }}');
+    gtag('config', '{{ analytics_tracking_id }}');
   </script>
 {% endif %}
 
-{# FIXME: <link rel="stylesheet" href="material.{{ theme.color-scheme | e ?: 'indigo-purple' }}.1.2.1.min.css"> #}
-<link rel="stylesheet" href="material.indigo-purple.1.2.1.min.css">
+<link rel="stylesheet" href="material.{{ theme_color_scheme | e ?: 'indigo-purple' }}.1.2.1.min.css">
 <link rel="stylesheet" href="styles.2.3.6.css">
 
 <script async src="material.1.2.1.min.js"></script>

--- a/modules/material/themes/material/default/header.twig
+++ b/modules/material/themes/material/default/header.twig
@@ -5,7 +5,7 @@
 
 <base href="{{ baseurlpath }}/module.php/material/">
 
-{% if analytics_tracking_id is not empty %}
+{% if analytics_tracking_id is defined and analytics_tracking_id is not empty %}
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id={{ analytics_tracking_id }}"></script>
   <script>
@@ -21,7 +21,7 @@
   </script>
 {% endif %}
 
-<link rel="stylesheet" href="material.{{ theme_color_scheme | e ?: 'indigo-purple' }}.1.2.1.min.css">
+<link rel="stylesheet" href="material.{{ (theme_color_scheme ?? 'indigo-purple')|e }}.1.2.1.min.css">
 <link rel="stylesheet" href="styles.2.3.6.css">
 
 <script async src="material.1.2.1.min.js"></script>

--- a/modules/mfa/public/low-on-backup-codes.php
+++ b/modules/mfa/public/low-on-backup-codes.php
@@ -31,6 +31,8 @@ if (filter_has_var(INPUT_POST, 'getMore')) {
 $globalConfig = Configuration::getInstance();
 
 $t = new Template($globalConfig, 'mfa:low-on-backup-codes');
+$t->data['theme_color_scheme'] = $globalConfig->getOptionalString('theme.color-scheme', '');
+$t->data['analytics_tracking_id'] = $globalConfig->getOptionalString('analytics.trackingId', '');
 $t->data['num_backup_codes_remaining'] = $state['numBackupCodesRemaining'];
 $t->send();
 

--- a/modules/mfa/public/must-set-up-mfa.php
+++ b/modules/mfa/public/must-set-up-mfa.php
@@ -1,11 +1,11 @@
 <?php
 
-use SimpleSAML\Module\mfa\LoggerFactory;
 use SimpleSAML\Auth\State;
 use SimpleSAML\Configuration;
 use SimpleSAML\Error\BadRequest;
-use SimpleSAML\XHTML\Template;
 use SimpleSAML\Module\mfa\Auth\Process\Mfa;
+use SimpleSAML\Module\mfa\LoggerFactory;
+use SimpleSAML\XHTML\Template;
 
 $stateId = filter_input(INPUT_GET, 'StateId') ?? null;
 if (empty($stateId)) {
@@ -24,6 +24,8 @@ if (filter_has_var(INPUT_POST, 'setUpMfa')) {
 $globalConfig = Configuration::getInstance();
 
 $t = new Template($globalConfig, 'mfa:must-set-up-mfa');
+$t->data['theme_color_scheme'] = $globalConfig->getOptionalString('theme.color-scheme', '');
+$t->data['analytics_tracking_id'] = $globalConfig->getOptionalString('analytics.trackingId', '');
 $t->send();
 
 $logger->info(sprintf(

--- a/modules/mfa/public/new-backup-codes.php
+++ b/modules/mfa/public/new-backup-codes.php
@@ -34,6 +34,8 @@ if (filter_has_var(INPUT_POST, 'continue')) {
 $globalConfig = Configuration::getInstance();
 
 $t = new Template($globalConfig, 'mfa:new-backup-codes');
+$t->data['theme_color_scheme'] = $globalConfig->getOptionalString('theme.color-scheme', '');
+$t->data['analytics_tracking_id'] = $globalConfig->getOptionalString('analytics.trackingId', '');
 $t->data['mfa_setup_url'] = $state['mfaSetupUrl'];
 $t->data['new_backup_codes'] = $state['newBackupCodes'] ?? [];
 $t->data['idp_name'] = $globalConfig->getString('idp_display_name');

--- a/modules/mfa/public/out-of-backup-codes.php
+++ b/modules/mfa/public/out-of-backup-codes.php
@@ -32,6 +32,8 @@ if (filter_has_var(INPUT_POST, 'getMore')) {
 $globalConfig = Configuration::getInstance();
 
 $t = new Template($globalConfig, 'mfa:out-of-backup-codes');
+$t->data['theme_color_scheme'] = $globalConfig->getOptionalString('theme.color-scheme', '');
+$t->data['analytics_tracking_id'] = $globalConfig->getOptionalString('analytics.trackingId', '');
 $t->data['has_other_mfa_options'] = $hasOtherMfaOptions;
 $t->send();
 

--- a/modules/mfa/public/prompt-for-mfa.php
+++ b/modules/mfa/public/prompt-for-mfa.php
@@ -120,6 +120,8 @@ foreach ($otherOptions as &$option) {
 $mfaTemplateToUse = Mfa::getTemplateFor($mfaOption['type']);
 
 $t = new Template($globalConfig, $mfaTemplateToUse);
+$t->data['theme_color_scheme'] = $globalConfig->getOptionalString('theme.color-scheme', '');
+$t->data['analytics_tracking_id'] = $globalConfig->getOptionalString('analytics.trackingId', '');
 $t->data['error_message'] = $errorMessage ?? null;
 $t->data['mfa_option_data'] = json_encode($mfaOption['data']);
 $t->data['mfa_options'] = $mfaOptions;

--- a/modules/mfa/public/send-manager-mfa.php
+++ b/modules/mfa/public/send-manager-mfa.php
@@ -36,6 +36,8 @@ if (filter_has_var(INPUT_POST, 'send')) {
 $globalConfig = Configuration::getInstance();
 
 $t = new Template($globalConfig, 'mfa:send-manager-mfa');
+$t->data['theme_color_scheme'] = $globalConfig->getOptionalString('theme.color-scheme', '');
+$t->data['analytics_tracking_id'] = $globalConfig->getOptionalString('analytics.trackingId', '');
 $t->data['manager_email'] = $state['managerEmail'];
 $t->data['error_message'] = $errorMessage ?? null;
 $t->send();

--- a/modules/profilereview/public/nag.php
+++ b/modules/profilereview/public/nag.php
@@ -31,6 +31,8 @@ if (filter_has_var(INPUT_POST, 'update')) {
 $globalConfig = Configuration::getInstance();
 
 $t = new Template($globalConfig, 'profilereview:' . $state['template']);
+$t->data['theme_color_scheme'] = $globalConfig->getOptionalString('theme.color-scheme', '');
+$t->data['analytics_tracking_id'] = $globalConfig->getOptionalString('analytics.trackingId', '');
 $t->data['profile_url'] = $state['profileUrl'];
 $t->data['method_options'] = $state['methodOptions'] ?? [];
 $t->data['mfa_options'] = $state['mfaOptions'] ?? [];

--- a/modules/profilereview/public/review.php
+++ b/modules/profilereview/public/review.php
@@ -35,6 +35,8 @@ if (filter_has_var(INPUT_POST, 'update')) {
 $globalConfig = Configuration::getInstance();
 
 $t = new Template($globalConfig, 'profilereview:review');
+$t->data['theme_color_scheme'] = $globalConfig->getOptionalString('theme.color-scheme', '');
+$t->data['analytics_tracking_id'] = $globalConfig->getOptionalString('analytics.trackingId', '');
 $t->data['profile_url'] = $state['profileUrl'];
 $t->data['method_options'] = $state['methodOptions'];
 $t->data['mfa_options'] = $state['mfaOptions'];

--- a/modules/silauth/public/loginuserpass.php
+++ b/modules/silauth/public/loginuserpass.php
@@ -80,6 +80,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 $t = new Template($globalConfig, 'silauth:loginuserpass');
+$t->data['theme_color_scheme'] = $globalConfig->getOptionalString('theme.color-scheme', '');
+$t->data['analytics_tracking_id'] = $globalConfig->getOptionalString('analytics.trackingId', '');
 $t->data['stateparams'] = array('AuthState' => $authStateId);
 $t->data['username'] = $username;
 $t->data['errorcode'] = $errorCode;


### PR DESCRIPTION
### Fixed
- Define template variables needed in the header template (`theme_color_scheme` and `analytics_tracking_id`)

_Note: It may be possible to reduce this code duplication by defining our own Template class, inherited from `SimpleSAML\XHTML\Template`, but I think that even that would have to be duplicated once for each module. Perhaps it could be extracted to our [ssp-utilities](https://github.com/silinternational/ssp-utilities) repo._