### PR TITLE
IDP-1041 remove expirychecker dateFormat

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,6 @@ Example (in `metadata/saml20-idp-hosted.php`):
             // Optional:
             'warnDaysBefore' => 14,
             'originalUrlParam' => 'originalurl',
-            'dateFormat' => 'm.d.Y', // Use PHP's date syntax.
             'loggerClass' => '\\Sil\\Psr3Adapters\\Psr3SamlLogger',
         ],
         
@@ -183,9 +182,6 @@ returned when the user successfully authenticates.
 
 The `warnDaysBefore` parameter should be an integer representing how many days
 before the expiry date the "about to expire" warning will be shown to the user.
-
-The `dateFormat` parameter specifies how you want the date to be formatted,
-using PHP `date()` syntax. See <http://php.net/manual/en/function.date.php>.
 
 The `loggerClass` parameter specifies the name of a PSR-3 compatible class that
 can be autoloaded, to use as the logger within ExpiryDate.

--- a/modules/expirychecker/src/Auth/Process/ExpiryDate.php
+++ b/modules/expirychecker/src/Auth/Process/ExpiryDate.php
@@ -32,7 +32,6 @@ class ExpiryDate extends ProcessingFilter
     private string|null $accountNameAttr = null;
     private string $employeeIdAttr = 'employeeNumber';
     private string|null $expiryDateAttr = null;
-    private string $dateFormat = 'Y-m-d';
 
     protected LoggerInterface $logger;
 
@@ -67,10 +66,6 @@ class ExpiryDate extends ProcessingFilter
                 Validator::NOT_EMPTY,
             ],
             'expiryDateAttr' => [
-                Validator::STRING,
-                Validator::NOT_EMPTY,
-            ],
-            'dateFormat' => [
                 Validator::STRING,
                 Validator::NOT_EMPTY,
             ],


### PR DESCRIPTION
### Removed
- Removed unused `dateFormat` option from the expirychecker module

https://itse.youtrack.cloud/issue/IDP-1041