### PR TITLE
remove config options that are not used

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,6 @@ Example (in `metadata/saml20-idp-hosted.php`):
 
             // Optional:
             'warnDaysBefore' => 14,
-            'originalUrlParam' => 'originalurl',
             'loggerClass' => '\\Sil\\Psr3Adapters\\Psr3SamlLogger',
         ],
         

--- a/development/idp-local/metadata/saml20-idp-hosted.php
+++ b/development/idp-local/metadata/saml20-idp-hosted.php
@@ -13,6 +13,7 @@ use Sil\SspBase\Features\fakes\FakeIdBrokerClient;
 
 $metadata['http://ssp-idp1.local:8085'] = [
     'entityid' => 'http://ssp-idp1.local:8085',
+    'name' => ['en' => 'IDP 1'],
 
     /*
      * The hostname of the server (VHOST) that will use this SAML entity.

--- a/development/idp2-local/metadata/saml20-idp-hosted.php
+++ b/development/idp2-local/metadata/saml20-idp-hosted.php
@@ -7,6 +7,7 @@
 
 $metadata['http://ssp-idp2.local:8086'] = [
     'entityid' => 'http://ssp-idp2.local:8086',
+    'name' => ['en' => 'IDP 2'],
 
     /*
      * The hostname of the server (VHOST) that will use this SAML entity.

--- a/development/idp3-local/metadata/saml20-idp-hosted.php
+++ b/development/idp3-local/metadata/saml20-idp-hosted.php
@@ -7,6 +7,7 @@
 
 $metadata['http://ssp-idp3.local:8087'] = [
     'entityid' => 'http://ssp-idp3.local:8087',
+    'name' => ['en' => 'IDP 3'],
 
     /*
      * The hostname of the server (VHOST) that will use this SAML entity.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -278,6 +278,7 @@ services:
     environment:
       ADMIN_EMAIL: "john_doe@there.com"
       ADMIN_PASS: "sp1"
+      IDP_NAME: "NA"
       SECRET_SALT: "not-secret-h57fjemb&dn^nsJFGNjweJz1"
       SECURE_COOKIE: "false"
       SHOW_SAML_ERRORS: "true"
@@ -300,6 +301,7 @@ services:
     environment:
       ADMIN_EMAIL: "john_doe@there.com"
       ADMIN_PASS: "sp2"
+      IDP_NAME: "NA"
       SECRET_SALT: "h57fjemb&dn^nsJFGNjweJz2"
       SECURE_COOKIE: "false"
       SHOW_SAML_ERRORS: "true"
@@ -324,6 +326,7 @@ services:
     environment:
       ADMIN_EMAIL: "john_doe@there.com"
       ADMIN_PASS: sp3
+      IDP_NAME: "NA"
       SECRET_SALT: h57fjemb&dn^nsJFGNjweJz3
       SECURE_COOKIE: "false"
       SHOW_SAML_ERRORS: "true"
@@ -344,6 +347,7 @@ services:
     environment:
       ADMIN_EMAIL: "john_doe@there.com"
       ADMIN_PASS: sp1
+      IDP_NAME: THIS VARIABLE IS REQUIRED BUT PROBABLY NOT USED
       SECRET_SALT: NOT-a-secret-k49fjfkw73hjf9t87wjiw
       SECURE_COOKIE: "false"
       SHOW_SAML_ERRORS: "true"
@@ -360,6 +364,7 @@ services:
     env_file:
       - ./local.broker.env
     environment:
+      IDP_NAME: "idp"
       MYSQL_HOST: "brokerDb"
       MYSQL_DATABASE: "broker"
       MYSQL_USER: "user"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,6 @@ services:
       PROFILE_URL_FOR_TESTS: http://pwmanager.local/module.php/core/authenticate.php?as=ssp-hub
       ADMIN_PASS: b
       SECRET_SALT: abc123
-      IDP_NAME: x
     volumes:
       - ./dockerbuild/run-integration-tests.sh:/data/run-integration-tests.sh
       - ./dockerbuild/run-metadata-tests.sh:/data/run-metadata-tests.sh
@@ -111,7 +110,6 @@ services:
     environment:
       ADMIN_PASS: "abc123"
       SECRET_SALT: "not-secret-h57fjemb&dn^nsJFGNjweJ"
-      IDP_NAME: "Hub"
       SECURE_COOKIE: "false"
       SHOW_SAML_ERRORS: "true"
       THEME_COLOR_SCHEME: "orange-light_blue"
@@ -162,7 +160,6 @@ services:
     environment:
       ADMIN_PASS: "a"
       SECRET_SALT: "not-secret-h57fjemb&dn^nsJFGNjweJ"
-      IDP_NAME: "IDP 1"
       IDP_DOMAIN_NAME: "mfaidp"
       ID_BROKER_ACCESS_TOKEN: "dummy"
       ID_BROKER_ASSERT_VALID_IP: "false"
@@ -217,7 +214,6 @@ services:
     environment:
       ADMIN_PASS: "b"
       SECRET_SALT: "h57fjemb&dn^nsJFGNjweJ"
-      IDP_NAME: "IDP 2"
       IDP_DOMAIN_NAME: "ssp-idp2.local"
       ID_BROKER_ACCESS_TOKEN: "test-cli-abc123"
       ID_BROKER_ASSERT_VALID_IP: "true"
@@ -261,7 +257,6 @@ services:
       SECRET_SALT: "h57fjem34fh*nsJFGNjweJ"
       SECURE_COOKIE: "false"
       SHOW_SAML_ERRORS: "true"
-      IDP_NAME: "IdP3"
       THEME_COLOR_SCHEME: "orange-light_blue"
 
   ssp-sp1.local:
@@ -283,7 +278,6 @@ services:
     environment:
       ADMIN_EMAIL: "john_doe@there.com"
       ADMIN_PASS: "sp1"
-      IDP_NAME: "NA"
       SECRET_SALT: "not-secret-h57fjemb&dn^nsJFGNjweJz1"
       SECURE_COOKIE: "false"
       SHOW_SAML_ERRORS: "true"
@@ -306,7 +300,6 @@ services:
     environment:
       ADMIN_EMAIL: "john_doe@there.com"
       ADMIN_PASS: "sp2"
-      IDP_NAME: "NA"
       SECRET_SALT: "h57fjemb&dn^nsJFGNjweJz2"
       SECURE_COOKIE: "false"
       SHOW_SAML_ERRORS: "true"
@@ -331,7 +324,6 @@ services:
     environment:
       ADMIN_EMAIL: "john_doe@there.com"
       ADMIN_PASS: sp3
-      IDP_NAME: "NA"
       SECRET_SALT: h57fjemb&dn^nsJFGNjweJz3
       SECURE_COOKIE: "false"
       SHOW_SAML_ERRORS: "true"
@@ -352,7 +344,6 @@ services:
     environment:
       ADMIN_EMAIL: "john_doe@there.com"
       ADMIN_PASS: sp1
-      IDP_NAME: THIS VARIABLE IS REQUIRED BUT PROBABLY NOT USED
       SECRET_SALT: NOT-a-secret-k49fjfkw73hjf9t87wjiw
       SECURE_COOKIE: "false"
       SHOW_SAML_ERRORS: "true"
@@ -369,7 +360,6 @@ services:
     env_file:
       - ./local.broker.env
     environment:
-      IDP_NAME: "idp"
       MYSQL_HOST: "brokerDb"
       MYSQL_DATABASE: "broker"
       MYSQL_USER: "user"

--- a/dockerbuild/config/config.php
+++ b/dockerbuild/config/config.php
@@ -56,7 +56,6 @@ $LOGGING_HANDLER = Env::get('LOGGING_HANDLER', 'stderr');
 $THEME_COLOR_SCHEME = Env::get('THEME_COLOR_SCHEME', null);
 
 $SECURE_COOKIE = Env::get('SECURE_COOKIE', true);
-$SESSION_DURATION = (int)(Env::get('SESSION_DURATION', (60 * 60 * 10))); // 10 hours.
 $SESSION_STORE_TYPE = Env::get('SESSION_STORE_TYPE', 'phpsession');
 $MYSQL_HOST = Env::get('MYSQL_HOST', '');
 $MYSQL_DATABASE = Env::get('MYSQL_DATABASE', '');
@@ -658,19 +657,19 @@ $config = [
      * This value is the duration of the session in seconds. Make sure that the time duration of
      * cookies both at the SP and the IdP exceeds this duration.
      */
-    'session.duration' => $SESSION_DURATION,
+    'session.duration' => (60 * 60 * 10), // 10 hours
 
     /*
      * Sets the duration, in seconds, data should be stored in the datastore. As the data store is used for
      * login and logout requests, this option will control the maximum time these operations can take.
      * The default is 4 hours (4*60*60) seconds, which should be more than enough for these operations.
      */
-    'session.datastore.timeout' => $SESSION_DURATION,
+    'session.datastore.timeout' => (60 * 60 * 10), // 10 hours
 
     /*
      * Sets the duration, in seconds, auth state should be stored.
      */
-    'session.state.timeout' => $SESSION_DURATION,
+    'session.state.timeout' => (60 * 60 * 10), // 10 hours
 
     /*
      * Option to override the default settings for the session cookie name
@@ -896,8 +895,7 @@ $config = [
      * Note: The oldest data will always be deleted if the memcache server
      * runs out of storage space.
      */
-    'memcache_store.expires' => $SESSION_DURATION + 3600, // Session duration plus an hour for clock skew
-
+    'memcache_store.expires' => (60 * 60 * 10) + 3600, // Session duration (10 hours) plus an hour for clock skew
 
 
     /*************************************

--- a/dockerbuild/config/config.php
+++ b/dockerbuild/config/config.php
@@ -63,7 +63,6 @@ $MYSQL_DATABASE = Env::get('MYSQL_DATABASE', '');
 $MYSQL_USER = Env::get('MYSQL_USER', '');
 $MYSQL_PASSWORD = Env::get('MYSQL_PASSWORD', '');
 
-$SAML20_IDP_ENABLE = Env::get('SAML20_IDP_ENABLE', true);
 $HUB_MODE = Env::get('HUB_MODE', false);
 $ANALYTICS_ID = Env::get('ANALYTICS_ID', null);
 $PASSWORD_CHANGE_URL = Env::get('PASSWORD_CHANGE_URL');
@@ -616,7 +615,7 @@ $config = [
      * one of the functionalities below, but in some cases you could run multiple functionalities.
      * In example when you are setting up a federation bridge.
      */
-    'enable.saml20-idp' => $SAML20_IDP_ENABLE,
+    'enable.saml20-idp' => true,
     'enable.adfs-idp' => false,
 
 

--- a/dockerbuild/config/config.php
+++ b/dockerbuild/config/config.php
@@ -29,7 +29,6 @@ try {
     // Required to be defined in environment variables
     $ADMIN_PASS = Env::requireEnv('ADMIN_PASS');
     $SECRET_SALT = Env::requireEnv('SECRET_SALT');
-    $IDP_NAME = Env::requireEnv('IDP_NAME');
 } catch (EnvVarNotFoundException $e) {
 
     // Return error response code/message to HTTP request.
@@ -45,7 +44,6 @@ try {
 }
 
 // Defaults provided if not defined in environment
-$IDP_DISPLAY_NAME = Env::get('IDP_DISPLAY_NAME', $IDP_NAME);
 $BASE_URL_PATH = Env::get('BASE_URL_PATH', '/');
 $ADMIN_EMAIL = Env::get('ADMIN_EMAIL', 'na@example.org');
 $ADMIN_NAME = Env::get('ADMIN_NAME', 'SAML Admin');
@@ -78,22 +76,12 @@ $config = [
     /*
      * Whether this instance should act as a hub/proxy/bridge using sildisco
      */
-     'hubmode' => $HUB_MODE,
+    'hubmode' => $HUB_MODE,
 
-     /*
-      * Name of this IdP
-      */
-     'idp_name' => $IDP_NAME,
-
-     /*
-      * Name of this IdP to display to the user
-      */
-     'idp_display_name' => $IDP_DISPLAY_NAME,
-
-     /*
-      * The tracking Id for Google Analytics or some other similar service
-      */
-     'analytics.trackingId' => $ANALYTICS_ID,
+    /*
+     * The tracking Id for Google Analytics or some other similar service
+     */
+    'analytics.trackingId' => $ANALYTICS_ID,
 
     'passwordChangeUrl' => $PASSWORD_CHANGE_URL,
     'passwordForgotUrl' => $PASSWORD_FORGOT_URL,

--- a/docs/the_hub.md
+++ b/docs/the_hub.md
@@ -24,9 +24,6 @@ It is also used by the `TagGroup.php` Auth Proc to convert group names into the 
 ##### SPList
 In order to limit access to an IdP to only certain SP's, add an `'SPList'` array entry to the metadata for the IdP.  The values of this array should match the `entity_id` values from the `sp-remote.php` metadata.
 
-##### excludeByDefault
-If you want to require SP's to list a certain IdP in their IDPList entry in order to be able to access it, add `excludeByDefault => true` to that IdP's metadata.
-
 ### Forced IdP discovery
 The `.../src/IdP/SAML2.php` file ensures that if an SP is allowed to access more than one IdP, then the user will be forced back to the IdP discovery page, even if they are already authenticated through one of those IdP's.
 

--- a/local.env.dist
+++ b/local.env.dist
@@ -1,6 +1,5 @@
 # These are Required
 ADMIN_PASS=
-IDP_NAME=
 SECRET_SALT=
 
 # These are Optional

--- a/modules/expirychecker/src/Auth/Process/ExpiryDate.php
+++ b/modules/expirychecker/src/Auth/Process/ExpiryDate.php
@@ -27,7 +27,6 @@ class ExpiryDate extends ProcessingFilter
     const SESSION_TYPE = 'expirychecker';
 
     private int $warnDaysBefore = 14;
-    private string $originalUrlParam = 'originalurl';
     private string|null $passwordChangeUrl = null;
     private string|null $accountNameAttr = null;
     private string $employeeIdAttr = 'employeeNumber';
@@ -52,10 +51,6 @@ class ExpiryDate extends ProcessingFilter
         $this->loadValuesFromConfig($config, [
             'warnDaysBefore' => [
                 Validator::INT,
-            ],
-            'originalUrlParam' => [
-                Validator::STRING,
-                Validator::NOT_EMPTY,
             ],
             'passwordChangeUrl' => [
                 Validator::STRING,
@@ -354,7 +349,6 @@ class ExpiryDate extends ProcessingFilter
 
         /* Save state and redirect. */
         $state['passwordChangeUrl'] = $this->passwordChangeUrl;
-        $state['originalUrlParam'] = $this->originalUrlParam;
 
         $id = State::saveState($state, 'expirychecker:expired');
         $url = Module::getModuleURL('expirychecker/expired.php');
@@ -389,7 +383,6 @@ class ExpiryDate extends ProcessingFilter
 
         /* Save state and redirect. */
         $state['passwordChangeUrl'] = $this->passwordChangeUrl;
-        $state['originalUrlParam'] = $this->originalUrlParam;
 
         $id = State::saveState($state, 'expirychecker:about2expire');
         $url = Module::getModuleURL('expirychecker/about2expire.php');

--- a/modules/expirychecker/src/Utilities.php
+++ b/modules/expirychecker/src/Utilities.php
@@ -13,7 +13,6 @@ class Utilities
      */
     public static function getUrlDomain(string $in_url, string $start_marker = '//', string $end_marker = '/'): string
     {
-
         $sm_len = strlen($start_marker);
         $em_len = strlen($end_marker);
         $start_pos = strpos($in_url, $start_marker);
@@ -45,43 +44,6 @@ class Utilities
             return 1;
         }
         return 0;
-    }
-
-    /**
-     * Expects four strings for ...
-     *  - the url for changing the user's password,
-     *  - the parameter label for the original url the user was headed to
-     *  - the original url the user was headed to
-     *  - the StateId parameter to add to the end of the new version of the url
-     * Returns a string with special symbols urlencoded and then also encoded
-     *  for apex to use. If the domains of the change password url and the
-     *  original url are different, it appends the StateId to the output.
-     */
-    public static function convertOriginalUrl(
-        string $passwordChangeUrl,
-        string $originalUrlParam,
-        string $originalUrl,
-        string $stateId
-    ): string {
-        $sameDomain = self::haveSameDomain($passwordChangeUrl,
-            '//', '/', $originalUrl, '//', '/');
-        $original = $originalUrlParam . ":" . urlencode($originalUrl);
-        // make changes that insite/apex needs in url
-        $original = str_replace('%3A', '*COLON*', $original);
-        $original = str_replace('%2C', '*COMMA*', $original);
-        $original = str_replace('%26', '*AMPER*', $original);
-
-        // if it already has a ?, then give it a &
-        // otherwise give it a ? ...
-        //  and then the StateId param
-        if (!$sameDomain) {
-            if (strpos($original, '%3F') !== false) {
-                $original = $original . "*AMPER*" . $stateId;
-            } else {
-                $original = $original . '%3F' . $stateId;
-            }
-        }
-        return $original;
     }
 
     /**

--- a/modules/mfa/public/new-backup-codes.php
+++ b/modules/mfa/public/new-backup-codes.php
@@ -36,7 +36,7 @@ $globalConfig = Configuration::getInstance();
 $t = new Template($globalConfig, 'mfa:new-backup-codes');
 $t->data['mfa_setup_url'] = $state['mfaSetupUrl'];
 $t->data['new_backup_codes'] = $state['newBackupCodes'] ?? [];
-$t->data['idp_name'] = $globalConfig->getString('idp_display_name');
+$t->data['idp_name'] = $t->getEntityDisplayName($state['IdPMetadata']);
 $t->data['codes_for_download'] = urlencode(
     $t->data['idp_name'] . "\r\n" . join("\r\n", $t->data['new_backup_codes'])
 );

--- a/modules/mfa/public/prompt-for-mfa.php
+++ b/modules/mfa/public/prompt-for-mfa.php
@@ -125,7 +125,7 @@ $browserJsHash = md5_file(__DIR__ . '/simplewebauthn/browser.js');
 $t->data['browser_js_path'] = '/module.php/mfa/simplewebauthn/browser.js?v=' . $browserJsHash;
 $t->data['manager_email'] = $state['managerEmail'];
 $t->data['other_options'] = $otherOptions;
-$t->data['idp_name'] = $globalConfig->getString('idp_display_name');
+$t->data['idp_name'] = $t->getEntityDisplayName($state['IdPMetadata']);
 $t->send();
 
 $logger->info(json_encode([

--- a/modules/silauth/public/loginuserpass.php
+++ b/modules/silauth/public/loginuserpass.php
@@ -88,7 +88,7 @@ $t->data['csrf_token'] = $csrfProtector->getMasterToken();
 $t->data['profile_url'] = $state['templateData']['profileUrl'] ?? '';
 $t->data['help_center_url'] = $state['templateData']['helpCenterUrl'] ?? '';
 $t->data['announcement'] = AnnouncementUtils::getAnnouncement();
-$t->data['idp_name'] = $globalConfig->getString('idp_display_name');
+$t->data['idp_name'] = $t->getEntityDisplayName($state['IdPMetadata']);
 $t->data['password_forgot_url'] = $globalConfig->getOptionalString('passwordForgotUrl', '');
 
 /* For simplicity's sake, don't bother telling this Request to trust any IP


### PR DESCRIPTION
### Removed
- Removed `originalUrlParam`
- Removed `excludeByDefault`
- Removed `IDP_NAME` and `IDP_DISPLAY_NAME` and use the metadata `name` property instead
- Removed `SAML20_IDP_ENABLE`
- Removed `SESSION_DURATION`

_**Note:** to study each removal separately, look at each commit one-by-one._


https://itse.youtrack.cloud/issue/IDP-1041