### PR TITLE
Release 10.0.2 -- assign all values nag controller needs

### DIFF
--- a/modules/profilereview/src/Auth/Process/ProfileReview.php
+++ b/modules/profilereview/src/Auth/Process/ProfileReview.php
@@ -222,7 +222,7 @@ class ProfileReview extends ProcessingFilter
         $isHeadedToProfileUrl = self::isHeadedToProfileUrl($state, $this->profileUrl);
 
         $mfa = $this->getAttributeAllValues('mfa', $state);
-        $method = $this->getAllMethods($state);
+        $method = $this->getMethod($state);
         $profileReview = $this->getAttribute('profile_review', $state);
 
         if (!$isHeadedToProfileUrl) {
@@ -267,8 +267,8 @@ class ProfileReview extends ProcessingFilter
      */
     protected function redirectToProfileReview(array &$state, string $employeeId): void
     {
-        $mfaOptions = $this->getAllMfasExceptManager($state);
-        $methodOptions = $this->getAllMethods($state)['options'];
+        $mfaOptions = $this->getAllMfaOptionsExceptManager($state);
+        $methodOptions = $this->getMethod($state)['options'];
 
         if (count($mfaOptions) == 0 && count($methodOptions) == 0) {
             return;
@@ -286,8 +286,8 @@ class ProfileReview extends ProcessingFilter
      */
     protected function redirectToNag(array &$state, string $employeeId, string $template): void
     {
-        $mfaOptions = $this->getAllMfasExceptManager($state);
-        $methodOptions = $this->getAllMethods($state)['options'];
+        $mfaOptions = $this->getAllMfaOptionsExceptManager($state);
+        $methodOptions = $this->getMethod($state)['options'];
 
         /* Save state and redirect. */
         $state['employeeId'] = $employeeId;
@@ -304,12 +304,12 @@ class ProfileReview extends ProcessingFilter
         $httpUtils->redirectTrustedURL($url, array('StateId' => $stateId));
     }
 
-    public function getAllMethods(array $state): ?array
+    public function getMethod(array $state): ?array
     {
         return $this->getAttributeAllValues('method', $state);
     }
 
-    protected function getAllMfasExceptManager(array $state): array
+    protected function getAllMfaOptionsExceptManager(array $state): array
     {
         $mfaOptions = $this->getAttributeAllValues('mfa', $state)['options'];
         foreach ($mfaOptions as $key => $mfaOption) {


### PR DESCRIPTION
[IDP-1043](https://itse.youtrack.cloud/issue/IDP-1043) ssp-base #203: nag.php expects array entries which aren't always being set

### Fixed
- Assign all values needed in the state by the nag.php page.

### Changed
- Refactor ProfileReview.php `redirectToProfileReview` and `redirectToNag` methods to pass fewer parameters and reduce code duplication.