### PR TITLE
Release 10.1.2 -- null coalesce to prevent a type error

### DIFF
--- a/modules/expirychecker/public/about2expire.php
+++ b/modules/expirychecker/public/about2expire.php
@@ -41,7 +41,7 @@ if (array_key_exists('changepwd', $_REQUEST)) {
         );
 
         $returnTo = Utilities::getUrlFromRelayState(
-            $state['saml:RelayState']
+            $state['saml:RelayState'] ?? ''
         );
         if (!empty($returnTo)) {
             $passwordChangeUrl .= '?returnTo=' . $returnTo;

--- a/modules/expirychecker/public/expired.php
+++ b/modules/expirychecker/public/expired.php
@@ -34,7 +34,7 @@ if (array_key_exists('changepwd', $_REQUEST)) {
         );
 
         $returnTo = Utilities::getUrlFromRelayState(
-            $state['saml:RelayState']
+            $state['saml:RelayState'] ?? ''
         );
         if (!empty($returnTo)) {
             $passwordChangeUrl .= '?returnTo=' . $returnTo;


### PR DESCRIPTION
[IDP-1249](https://itse.youtrack.cloud/issue/IDP-1249) Clicking "Yes" when prompted to reset password (by expirychecker) triggers an error

---

### Fixed
- Add a null coalesce to prevent a type error.