### PR TITLE
Fix annotation to refer to the team, rather than a (former) member

### DIFF
--- a/modules/sildisco/src/IdPDisco.php
+++ b/modules/sildisco/src/IdPDisco.php
@@ -20,7 +20,7 @@ use yii\db\Exception;
  *
  * This module extends the basic IdP disco handler.
  *
- * @author Steve Bagwell SIL GTIS
+ * @author SIL GTIS
  * @package SimpleSAMLphp
  */
 class IdPDisco extends SSPIdPDisco


### PR DESCRIPTION
### Fixed
- Fix annotation to refer to the team, rather than a (former) member