### PR TITLE
Release - Remove unused css and re-center content in body

### DIFF
--- a/modules/material/public/styles.2.3.6.css
+++ b/modules/material/public/styles.2.3.6.css
@@ -1,3 +1,7 @@
+body {
+  display: grid;
+}
+
 p {
   max-width: 60ch;
 }
@@ -5,11 +9,6 @@ p {
 pre {
   white-space: pre-line;
   max-width: 100%;
-}
-
-.fill-viewport {
-  width: 100vw;
-  height: 100vh;
 }
 
 [layout-children=row] {


### PR DESCRIPTION
Fixed - The content was at the top which was only noticeable on bigger screen, but this centers is after having removed fill-viewport

<img width="836" alt="image" src="https://github.com/user-attachments/assets/37504ca2-a9d4-466a-bb1b-7d1385d24c0f">