### PR TITLE
fix config-shim parameters

### DIFF
--- a/dockerbuild/run.sh
+++ b/dockerbuild/run.sh
@@ -23,7 +23,11 @@ php -v | head -n 1
 if [[ -z "${APP_ID}" ]]; then
   apache2ctl -k start -D FOREGROUND
 else
-  config-shim -u --strategy $STRATEGY_ID --app $APP_ID --config $CONFIG_ID --env $ENV_ID apache2ctl -k start -D FOREGROUND
+  if [[ -z "${STRATEGY_ID}" ]]; then
+    config-shim --app $APP_ID --config $CONFIG_ID --env $ENV_ID apache2ctl -k start -D FOREGROUND
+  else 
+    config-shim -u --strategy $STRATEGY_ID --app $APP_ID --config $CONFIG_ID --env $ENV_ID apache2ctl -k start -D FOREGROUND
+  fi
 fi
 
 # endless loop with a wait is needed for the trap to work


### PR DESCRIPTION
### Fixed
- Fixed the run.sh script so it doesn't try to use the `-u` and `--strategy` flags on config-shim if `STRATEGY_ID` is empty.