### PR TITLE
Fix load listener

### DIFF
--- a/modules/material/themes/material/mfa/new-backup-codes.twig
+++ b/modules/material/themes/material/mfa/new-backup-codes.twig
@@ -12,8 +12,6 @@
         if (bowser.msie) {
           disablePrint();
           disableDownload();
-        } else if (bowser.msedge) {
-          disableDownload();
         }
       }
 

--- a/modules/material/themes/material/mfa/new-backup-codes.twig
+++ b/modules/material/themes/material/mfa/new-backup-codes.twig
@@ -49,7 +49,8 @@
         window.print();
       }
 
-      document.querySelector('body').addEventListener('load', disableUnsupportedFeatures);
+      disableUnsupportedFeatures();
+
       document.getElementById('print').addEventListener('click', function() {
         printElement('#code-card');
       });

--- a/modules/material/themes/material/profilereview/review.twig
+++ b/modules/material/themes/material/profilereview/review.twig
@@ -24,7 +24,8 @@
         node.innerText = `${label} ${date.toLocaleDateString()} ${date.toLocaleTimeString()}`
       }
 
-      document.querySelector('body').addEventListener('load', prettifyDates)
+      prettifyDates();
+
       document.getElementById('launch').addEventListener('click', function(e) {
         document.getElementsByName('continue').click()
       });


### PR DESCRIPTION
[IDP-1340](https://itse.youtrack.cloud/issue/IDP-1340) ssp-base body event listener not triggered

### Fixed
- Directly call the `disableUnsupportedFeatures` and `prettifyDates` functions in the `DOMContentLoaded` listener instead of using `addEventListener` on the `body`.
- Enable printable code download on Edge.