### PR TITLE
Release 10.1.19 - standardize webauthn initiation button

### DIFF
--- a/modules/material/locales/en/LC_MESSAGES/material.po
+++ b/modules/material/locales/en/LC_MESSAGES/material.po
@@ -138,7 +138,7 @@ msgid "{mfa:webauthn_instructions}"
 msgstr "Follow the prompts to use your key."
 
 msgid "{mfa:webauthn_start}"
-msgstr "Click OK when you're ready to start."
+msgstr "Click Verify when you're ready to start."
 
 msgid "{mfa:webauthn_error_unknown}"
 msgstr "Something went wrong with that request, unable to verify at this time."

--- a/modules/material/locales/es/LC_MESSAGES/material.po
+++ b/modules/material/locales/es/LC_MESSAGES/material.po
@@ -138,7 +138,7 @@ msgid "{mfa:webauthn_instructions}"
 msgstr "Siga las instrucciones para usar su clave."
 
 msgid "{mfa:webauthn_start}"
-msgstr "Haga clic en OK cuando esté listo para comenzar."
+msgstr "Haga clic en Verificar cuando esté listo para comenzar."
 
 msgid "{mfa:webauthn_error_unknown}"
 msgstr "Algo salió mal con esa solicitud, no se pudo verificar en este momento."

--- a/modules/material/locales/fr/LC_MESSAGES/material.po
+++ b/modules/material/locales/fr/LC_MESSAGES/material.po
@@ -138,7 +138,7 @@ msgid "{mfa:webauthn_instructions}"
 msgstr "Suivez les instructions pour utiliser votre clé."
 
 msgid "{mfa:webauthn_start}"
-msgstr "Cliquez sur OK lorsque vous êtes prêt à commencer."
+msgstr "Cliquez sur Vérifier lorsque vous êtes prêt à commencer."
 
 msgid "{mfa:webauthn_error_unknown}"
 msgstr "Quelque chose s'est mal passé avec cette demande, impossible de vérifier pour le moment."

--- a/modules/material/themes/material/mfa/prompt-for-mfa-webauthn.twig
+++ b/modules/material/themes/material/mfa/prompt-for-mfa-webauthn.twig
@@ -22,8 +22,6 @@
         const errorNode = document.querySelector('p.error');
         errorNode.classList.remove('hide');
         errorNode.querySelector('span').textContent = errorMessage;
-
-        offerRetry();
       }
 
       function createMessage(error) {
@@ -35,15 +33,6 @@
           default:
             return '{{ '{mfa:webauthn_error_unknown}'|trans|e('js')|raw }}';
         }
-      }
-
-      function offerRetry() {
-        const verifyBtn = document.getElementById('verifyBtn');
-
-        verifyBtn.classList.add('mdl-color-text--red');
-        verifyBtn.classList.remove('mdl-color-text--primary');
-        verifyBtn.textContent = '{{ '{mfa:button_try_again}'|trans|e('js') }}';
-
       }
 
       function submitForm(webAuthnResponse) {
@@ -126,14 +115,10 @@
           {{ include('other_mfas.twig') }}
 
           <span flex></span>
-          
+
           <!-- used type=button to avoid form submission on click -->
-          <button
-            id="verifyBtn"
-            type="button"
-            class="mdl-button mdl-button--raised {{ error_message is empty ? 'mdl-color-text--primary' : 'mdl-color-text--red' }}"
-          >
-            {{ error_message is empty ? 'ok' : '{mfa:button_try_again}'|trans }}
+          <button id="verifyBtn" type="button" class="mdl-button mdl-button--raised mdl-button--primary">
+            {{ '{mfa:button_verify}'|trans }}
           </button>
         </div>
 


### PR DESCRIPTION
[IDP-1425](https://itse.youtrack.cloud/issue/IDP-1425)

### Fixed
- Change OK button to use same text and formatting as other 2SV submit buttons

### Notes
- Oddly enough, there was no suggested change for Korean, so leaving it as is.