### PR TITLE
Release 10.2.4 -- remove config-shim to use the version in the silintl/php8 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,9 +47,6 @@ COPY dockerbuild/config/* $SSP_PATH/config/
 COPY dockerbuild/ssp-overrides/sp-php.patch sp-php.patch
 RUN patch /data/vendor/simplesamlphp/simplesamlphp/modules/saml/src/Auth/Source/SP.php sp-php.patch
 
-ADD https://github.com/silinternational/config-shim/releases/download/v1.2.0/config-shim.gz config-shim.gz
-RUN gzip -d config-shim.gz && chmod 755 config-shim && mv config-shim /usr/local/bin
-
 # Set permissions for cache directory. Corresponds to the `cachedir` setting in config.php.
 RUN mkdir /data/cache
 RUN chown -R www-data:www-data /data/cache


### PR DESCRIPTION
### Removed
- Removed config-shim from Dockerfile to use the version in the silintl/php8 base image


### PR Checklist
- [x] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)
- [x] ~Documentation (README, etc.)~
- [x] ~Unit tests created or updated~
- [x] ~Run `make composershow`~
