### PR TITLE
change to RECAPTCHA_SECRET_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ Optional configuration is described below.
 
 ##### Google reCAPTCHA
 
-If a site key and secret have been provided in the `RECAPTCHA_SITE_KEY` and `RECAPTCHA_SECRET`
+If a site key and secret have been provided in the `RECAPTCHA_SITE_KEY` and `RECAPTCHA_SECRET_KEY`
 environment variables, the username/password page may require the user prove his/her humanity.
 
 ##### Branding
@@ -558,7 +558,7 @@ MYSQL_DATABASE=
 MYSQL_USER=
 MYSQL_PASSWORD=
 RECAPTCHA_SITE_KEY=
-RECAPTCHA_SECRET=
+RECAPTCHA_SECRET_KEY=
 PROFILE_URL=
 HELP_CENTER_URL=
 ```

--- a/README.md
+++ b/README.md
@@ -339,6 +339,8 @@ Optional configuration is described below.
 If a site key and secret have been provided in the `RECAPTCHA_SITE_KEY` and `RECAPTCHA_SECRET_KEY`
 environment variables, the username/password page may require the user prove his/her humanity.
 
+Deprecated: `RECAPTCHA_SECRET` is deprecated and will be removed in the next major version.
+
 ##### Branding
 
 Set the `THEME_COLOR_SCHEME` environment variable using one of the following values:

--- a/local.env.dist
+++ b/local.env.dist
@@ -125,12 +125,12 @@ MFA_LEARN_MORE_URL=
 # will be used in a "Forgot password?" link on the 'loginuserpass' page.
 PASSWORD_FORGOT_URL=
 
-# RECAPTCHA_SITE_KEY and RECAPTCHA_SECRET can be set to a Google reCAPTCHA key and secret. If set,
+# RECAPTCHA_SITE_KEY and RECAPTCHA_SECRET_KEY can be set to a Google reCAPTCHA key and secret. If set,
 # excessive failed logins will trigger a CAPTCHA prompt that must be completed for continued login
 # attempts.
 # See "https://developers.google.com/recaptcha/docs/faq" for test key/secret.
 RECAPTCHA_SITE_KEY=
-RECAPTCHA_SECRET=
+RECAPTCHA_SECRET_KEY=
 
 # SESSION_STORE_TYPE sets the SimpleSAMLphp session store type. It can be 'sql' or 'phpsession'.
 # The default is 'phpsession'. It is not recommended to use 'phpsession' in production.

--- a/modules/silauth/src/Auth/Source/config/ssp-config.php
+++ b/modules/silauth/src/Auth/Source/config/ssp-config.php
@@ -15,7 +15,7 @@ return [
     'mysql.user' => Env::get('MYSQL_USER'),
     'mysql.password' => Env::get('MYSQL_PASSWORD'),
     'recaptcha.siteKey' => Env::get('RECAPTCHA_SITE_KEY'),
-    'recaptcha.secret' => Env::get('RECAPTCHA_SECRET'),
+    'recaptcha.secret' => Env::get('RECAPTCHA_SECRET_KEY', Env::get('RECAPTCHA_SECRET')),
     'templateData.profileUrl' => Env::get('PROFILE_URL'),
     'templateData.helpCenterUrl' => Env::get('HELP_CENTER_URL'),
 ];


### PR DESCRIPTION
### Changed
- Change `RECAPTCHA_SECRET` to `RECAPTCHA_SECRET_KEY` to align with the variable name used in [idp-pw-api](https://github.com/silinternational/idp-pw-api), while still accepting `RECAPTCHA_SECRET` for compatibility.

### Deprecated
- The variable `RECAPTCHA_SECRET` is being deprecated. Use `RECAPTCHA_SECRET_KEY` instead.