### PR TITLE
Requesting MFA code be sent to a recovery contact

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -275,6 +275,9 @@ services:
       # Customized SSP code -- TODO: make a better solution that doesn't require hacking SSP code
       - ./development/UserPass.php:/data/vendor/simplesamlphp/simplesamlphp/modules/exampleauth/src/Auth/Source/UserPass.php
 
+      # Include the features folder (for the FakeIdBrokerClient class)
+      - ./features:/data/features
+
       # Local modules
       - ./modules/mfa:/data/vendor/simplesamlphp/simplesamlphp/modules/mfa
       - ./modules/expirychecker:/data/vendor/simplesamlphp/simplesamlphp/modules/expirychecker

--- a/features/bootstrap/MfaRecoveryContext.php
+++ b/features/bootstrap/MfaRecoveryContext.php
@@ -1,5 +1,6 @@
 <?php
 
+use Behat\Step\When;
 use Behat\Mink\Element\DocumentElement;
 use Behat\Step\Given;
 use Behat\Step\Then;
@@ -65,5 +66,36 @@ class MfaRecoveryContext extends MfaContext
         );
 
         $this->assertHasSendButton($page);
+    }
+
+    #[When('I send the code to the recovery contact')]
+    public function iSendTheCodeToTheRecoveryContact(): void
+    {
+        $this->selectARecoveryContactOption();
+        $this->submitFormByClickingButtonNamed('send');
+    }
+
+    protected function selectARecoveryContactOption(): void
+    {
+        $page = $this->session->getPage();
+        $contactOptionElements = $page->findAll('css', 'input[name=mfaRecoveryContactID]');
+        foreach ($contactOptionElements as $element) {
+            $elementID = $element->getAttribute('id');
+            if ($elementID !== 'option-manager') {
+                $element->click();
+                return;
+            }
+        }
+        Assert::fail('Failed to find a way to select a (non-manager) recovery contact');
+    }
+
+    #[Then('I should see confirmation that the code was sent')]
+    public function iShouldSeeConfirmationThatTheCodeWasSent(): void
+    {
+        $page = $this->session->getPage();
+        Assert::assertContains(
+            'A temporary code was sent to your recovery contact.',
+            $page->getContent()
+        );
     }
 }

--- a/features/bootstrap/MfaRecoveryContext.php
+++ b/features/bootstrap/MfaRecoveryContext.php
@@ -89,6 +89,16 @@ class MfaRecoveryContext extends MfaContext
         Assert::fail('Failed to find a way to select a (non-manager) recovery contact');
     }
 
+    #[Then('I should not see an error message')]
+    public function iShouldNotSeeAnErrorMessage(): void
+    {
+        $page = $this->session->getPage();
+        Assert::assertNotContains(
+            'error',
+            $page->getContent()
+        );
+    }
+
     #[Then('I should see confirmation that the code was sent')]
     public function iShouldSeeConfirmationThatTheCodeWasSent(): void
     {

--- a/features/fakes/FakeIdBrokerClient.php
+++ b/features/fakes/FakeIdBrokerClient.php
@@ -116,6 +116,13 @@ class FakeIdBrokerClient
             ];
         }
 
+        if ($type === 'recovery') {
+            return [
+                "id" => 7890,
+                "data" => [],
+            ];
+        }
+
         throw new InvalidArgumentException(sprintf(
             'This Fake ID Broker class does not support creating %s MFA records.',
             $type

--- a/features/mfa-recovery.feature
+++ b/features/mfa-recovery.feature
@@ -17,3 +17,12 @@ Feature: Send a code to an MFA recovery contact
     When I click the Request Assistance link
     Then I should see a way to send an MFA recovery code to my manager
     And I should see a way to send an MFA recovery code to another recovery contact
+
+  Scenario: User with manager and recovery contact, send code to recovery contact
+    Given I use an IDP that is configured to offer MFA recovery-contacts
+    And I provide credentials that have backup codes
+    And the user has a manager email
+    And I log in
+    And I click the Request Assistance link
+    When I send the code to the recovery contact
+    Then I should see confirmation that the code was sent

--- a/features/mfa-recovery.feature
+++ b/features/mfa-recovery.feature
@@ -25,4 +25,5 @@ Feature: Send a code to an MFA recovery contact
     And I log in
     And I click the Request Assistance link
     When I send the code to the recovery contact
-    Then I should see confirmation that the code was sent
+    Then I should not see an error message
+    And I should see confirmation that the code was sent

--- a/modules/material/locales/en/LC_MESSAGES/material.po
+++ b/modules/material/locales/en/LC_MESSAGES/material.po
@@ -182,6 +182,9 @@ msgstr "your supervisor"
 msgid "{mfa:recovery_sent}"
 msgstr "A temporary code was sent to your recovery contact."
 
+msgid "{mfa:recovery_input}"
+msgstr "Enter code"
+
 msgid "{mfa:shield_icon}"
 msgstr "Shield icon"
 

--- a/modules/material/locales/es/LC_MESSAGES/material.po
+++ b/modules/material/locales/es/LC_MESSAGES/material.po
@@ -182,6 +182,9 @@ msgstr "su supervisor"
 msgid "{mfa:recovery_sent}"
 msgstr "Se envió un código temporal a su contacto de recuperación."
 
+msgid "{mfa:recovery_input}"
+msgstr "Introduce el código"
+
 msgid "{mfa:shield_icon}"
 msgstr "Icono de escudo"
 

--- a/modules/material/locales/fr/LC_MESSAGES/material.po
+++ b/modules/material/locales/fr/LC_MESSAGES/material.po
@@ -182,6 +182,9 @@ msgstr "votre superviseur"
 msgid "{mfa:recovery_sent}"
 msgstr "Un code temporaire a été envoyé à votre contact de récupération."
 
+msgid "{mfa:recovery_input}"
+msgstr "Entrer le code"
+
 msgid "{mfa:shield_icon}"
 msgstr "Icône de bouclier"
 

--- a/modules/material/locales/ko/LC_MESSAGES/material.po
+++ b/modules/material/locales/ko/LC_MESSAGES/material.po
@@ -182,6 +182,9 @@ msgstr "당신의 상사"
 msgid "{mfa:recovery_sent}"
 msgstr "복구 연락처로 임시 코드가 전송되었습니다."
 
+msgid "{mfa:recovery_input}"
+msgstr "코드 입력"
+
 msgid "{mfa:shield_icon}"
 msgstr "방패 아이콘"
 

--- a/modules/material/themes/material/mfa/prompt-for-mfa-recovery.twig
+++ b/modules/material/themes/material/mfa/prompt-for-mfa-recovery.twig
@@ -31,7 +31,7 @@
 
         <div class="mdl-card__title center">
           <p class="mdl-card__subtitle-text">
-            {{ '{mfa:recovery_sent}' }}
+            {{ '{mfa:recovery_sent}'|trans }}
           </p>
         </div>
 

--- a/modules/material/themes/material/mfa/prompt-for-mfa-recovery.twig
+++ b/modules/material/themes/material/mfa/prompt-for-mfa-recovery.twig
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="{{ currentLanguage }}">
+<head>
+  <title>{{ '{mfa:title}'|trans }}</title>
+
+  {{ include('header.twig') }}
+
+  <script src="{{ remember_me_js_path }}"></script>
+</head>
+<body class="gradient-bg">
+<div class="mdl-layout mdl-layout--fixed-header">
+  <header class="mdl-layout__header">
+    <div class="mdl-layout__header-row">
+      <span class="mdl-layout-title">
+        {{ '{mfa:header}'|trans }}
+      </span>
+    </div>
+  </header>
+  <main class="mdl-layout__content" layout-children="column">
+    <form layout-children="column" method="post" autocomplete="off">
+      <div class="mdl-card mdl-shadow--8dp">
+        <div class="mdl-card__media white-bg margin" layout-children="column">
+          <img src="mfa-manager.svg" class="icon" alt="{{ '{mfa:manager_icon}'|trans }}">
+        </div>
+
+        <div class="mdl-card__title center">
+          <h1 class="mdl-card__title-text">
+            {{ '{mfa:manager_header}'|trans }}
+          </h1>
+        </div>
+
+        <div class="mdl-card__title center">
+          <p class="mdl-card__subtitle-text">
+            {{ '{mfa:manager_sent}'|trans({'%managerEmail%': manager_email}) }}
+          </p>
+        </div>
+
+        <div class="mdl-card__supporting-text" layout-children="column">
+          <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+            <label for="mfaSubmission" class="mdl-textfield__label">
+              {{ '{mfa:manager_input}'|trans }}
+            </label>
+            <input name="mfaSubmission" class="mdl-textfield__input mdl-color-text--black" autofocus id="mfaSubmission">
+          </div>
+        </div>
+
+        {% if error_message is not empty %}
+          <div class="mdl-card__supporting-text" layout-children="column">
+            <p class="mdl-color-text--red error">
+              <i class="material-icons">error</i>
+
+              <span class="mdl-typography--caption">
+                {{ error_message|e }}
+              </span>
+            </p>
+          </div>
+
+          {% if analytics_tracking_id is not empty %}
+            <script>
+              gtag('event', '{{ error_message|e('js')|raw }}', {
+                'event_category': 'error',
+                'event_label': 'managercode'
+              });
+            </script>
+          {% endif %}
+        {% endif %}
+
+        <div class="mdl-card__actions" layout-children="row">
+          {{ include('other_mfas.twig') }}
+
+          <span flex></span>
+
+          <button name="submitMfa" type="submit" class="mdl-button mdl-button--raised mdl-button--primary">
+            {{ '{mfa:button_verify}'|trans }}
+          </button>
+        </div>
+      </div>
+
+      <div>
+        <label for="rememberMe"  class="mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect">
+          <span class="mdl-checkbox__label">
+            {{ '{mfa:remember_this}'|trans }}
+          </span>
+          <input type="checkbox" id="rememberMe"  name="rememberMe" {% if rememberMePreference == 'checked' %}checked{% endif %} class="mdl-checkbox__input">
+        </label>
+      </div>
+    </form>
+  </main>
+</div>
+</body>
+</html>

--- a/modules/material/themes/material/mfa/prompt-for-mfa-recovery.twig
+++ b/modules/material/themes/material/mfa/prompt-for-mfa-recovery.twig
@@ -20,25 +20,25 @@
     <form layout-children="column" method="post" autocomplete="off">
       <div class="mdl-card mdl-shadow--8dp">
         <div class="mdl-card__media white-bg margin" layout-children="column">
-          <img src="mfa-manager.svg" class="icon" alt="{{ '{mfa:manager_icon}'|trans }}">
+          <img src="mfa-recovery.svg" class="icon" alt="{{ '{mfa:recovery_icon}'|trans }}">
         </div>
 
         <div class="mdl-card__title center">
           <h1 class="mdl-card__title-text">
-            {{ '{mfa:manager_header}'|trans }}
+            {{ '{mfa:recovery_header}'|trans }}
           </h1>
         </div>
 
         <div class="mdl-card__title center">
           <p class="mdl-card__subtitle-text">
-            {{ '{mfa:manager_sent}'|trans({'%managerEmail%': manager_email}) }}
+            {{ '{mfa:recovery_sent}' }}
           </p>
         </div>
 
         <div class="mdl-card__supporting-text" layout-children="column">
           <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
             <label for="mfaSubmission" class="mdl-textfield__label">
-              {{ '{mfa:manager_input}'|trans }}
+              {{ '{mfa:recovery_input}'|trans }}
             </label>
             <input name="mfaSubmission" class="mdl-textfield__input mdl-color-text--black" autofocus id="mfaSubmission">
           </div>
@@ -59,7 +59,7 @@
             <script>
               gtag('event', '{{ error_message|e('js')|raw }}', {
                 'event_category': 'error',
-                'event_label': 'managercode'
+                'event_label': 'recoverycode'
               });
             </script>
           {% endif %}

--- a/modules/mfa/src/Auth/Process/Mfa.php
+++ b/modules/mfa/src/Auth/Process/Mfa.php
@@ -335,6 +335,7 @@ class Mfa extends ProcessingFilter
             'totp' => 'mfa:prompt-for-mfa-totp',
             'webauthn' => 'mfa:prompt-for-mfa-webauthn',
             'manager' => 'mfa:prompt-for-mfa-manager',
+            'recovery' => 'mfa:prompt-for-mfa-recovery',
         ];
         $template = $mfaOptionTemplates[$mfaType] ?? null;
 

--- a/modules/mfa/src/Auth/Process/Mfa.php
+++ b/modules/mfa/src/Auth/Process/Mfa.php
@@ -939,17 +939,22 @@ class Mfa extends ProcessingFilter
     }
 
     /**
-     * Send a rescue code to the manager, then redirect the user to a page where they
-     * can enter the code.
+     * Send a rescue code to the specified recovery contact, then redirect the
+     * user to a page where they can enter the code.
      *
      * If successful, this function triggers a redirect and does not return
      *
      * @param array $state The state data.
+     * @param string $mfaRecoveryContactID The identifier for the selected MFA
+     *     recovery contact.
      * @param LoggerInterface $logger A PSR-3 compatible logger.
      * @throws Exception
      */
-    public static function sendRecoveryCode(array &$state, LoggerInterface $logger): void
-    {
+    public static function sendRecoveryCode(
+        array &$state,
+        string $mfaRecoveryContactID,
+        LoggerInterface $logger
+    ): void {
         try {
             $idBrokerClient = self::getIdBrokerClient($state['idBrokerConfig']);
             $mfaOption = $idBrokerClient->mfaCreate($state['employeeId'], 'manager');

--- a/modules/mfa/src/Auth/Process/Mfa.php
+++ b/modules/mfa/src/Auth/Process/Mfa.php
@@ -233,7 +233,7 @@ class Mfa extends ProcessingFilter
         }
 
         $recentMfa = self::getMostRecentUsedMfaOption($mfaOptions);
-        $mfaTypePriority = ['manager'];
+        $mfaTypePriority = ['recovery', 'manager'];
 
         if (isset($recentMfa['type'])) {
             $mfaTypePriority[] = $recentMfa['type'];

--- a/modules/mfa/src/Auth/Process/Mfa.php
+++ b/modules/mfa/src/Auth/Process/Mfa.php
@@ -939,6 +939,54 @@ class Mfa extends ProcessingFilter
     }
 
     /**
+     * Send a rescue code to the manager, then redirect the user to a page where they
+     * can enter the code.
+     *
+     * If successful, this function triggers a redirect and does not return
+     *
+     * @param array $state The state data.
+     * @param LoggerInterface $logger A PSR-3 compatible logger.
+     * @throws Exception
+     */
+    public static function sendRecoveryCode(array &$state, LoggerInterface $logger): void
+    {
+        try {
+            $idBrokerClient = self::getIdBrokerClient($state['idBrokerConfig']);
+            $mfaOption = $idBrokerClient->mfaCreate($state['employeeId'], 'manager');
+            $mfaOption['type'] = 'manager';
+
+            $logger->warning(json_encode([
+                'event' => 'Manager rescue code sent',
+                'employeeId' => $state['employeeId'],
+            ]));
+        } catch (Throwable $t) {
+            $logger->error(json_encode([
+                'event' => 'Manager rescue code: failed',
+                'employeeId' => $state['employeeId'],
+                'error' => $t->getCode() . ': ' . $t->getMessage(),
+            ]));
+            throw new Exception('There was an unexpected error. Please try again ' .
+                'or contact tech support for assistance');
+        }
+
+        $mfaOptions = $state['mfaOptions'];
+
+        /*
+         * Add this option into the list, giving it a key so `mfaOptions` doesn't get multiple entries
+         * if the user tries multiple times.
+         */
+        $mfaOptions['manager'] = $mfaOption;
+        $state['mfaOptions'] = $mfaOptions;
+        $state['managerEmail'] = self::getMaskedManagerEmail($state);
+        $stateId = State::saveState($state, self::STAGE_SENT_TO_MFA_PROMPT);
+
+        $url = Module::getModuleURL('mfa/prompt-for-mfa.php');
+
+        $httpUtils = new HTTP();
+        $httpUtils->redirectTrustedURL($url, ['mfaId' => $mfaOption['id'], 'StateId' => $stateId]);
+    }
+
+    /**
      * Get masked copy of manager_email, or null if it isn't available.
      *
      * @param array $state

--- a/modules/mfa/src/Auth/Process/Mfa.php
+++ b/modules/mfa/src/Auth/Process/Mfa.php
@@ -958,21 +958,23 @@ class Mfa extends ProcessingFilter
     ): void {
         try {
             $idBrokerClient = self::getIdBrokerClient($state['idBrokerConfig']);
-            $mfaOption = $idBrokerClient->mfaCreate($state['employeeId'], 'manager');
-            $mfaOption['type'] = 'manager';
+            $mfaOption = $idBrokerClient->mfaCreate($state['employeeId'], 'recovery');
+            $mfaOption['type'] = 'recovery';
 
             $logger->warning(json_encode([
-                'event' => 'Manager rescue code sent',
+                'event' => 'Recovery code sent',
                 'employeeId' => $state['employeeId'],
             ]));
         } catch (Throwable $t) {
             $logger->error(json_encode([
-                'event' => 'Manager rescue code: failed',
+                'event' => 'Recovery code: failed',
                 'employeeId' => $state['employeeId'],
                 'error' => $t->getCode() . ': ' . $t->getMessage(),
             ]));
-            throw new Exception('There was an unexpected error. Please try again ' .
-                'or contact tech support for assistance');
+            throw new Exception(
+                'There was an unexpected error. Please try again or contact ' .
+                'tech support for assistance'
+            );
         }
 
         $mfaOptions = $state['mfaOptions'];
@@ -981,9 +983,8 @@ class Mfa extends ProcessingFilter
          * Add this option into the list, giving it a key so `mfaOptions` doesn't get multiple entries
          * if the user tries multiple times.
          */
-        $mfaOptions['manager'] = $mfaOption;
+        $mfaOptions['recovery'] = $mfaOption;
         $state['mfaOptions'] = $mfaOptions;
-        $state['managerEmail'] = self::getMaskedManagerEmail($state);
         $stateId = State::saveState($state, self::STAGE_SENT_TO_MFA_PROMPT);
 
         $url = Module::getModuleURL('mfa/prompt-for-mfa.php');


### PR DESCRIPTION
### Added
- Add test for submitting request to send code to a recovery contact
- Adapt `sendManagerCode()` to create a similar `sendRecoveryCode()`
- Adapt `prompt-for-mfa-manager` view template to create a `prompt-for-mfa-recovery` view template

### Fixed
- Ensure local IDP4 has the FakeIdBroker Client, for testing
- Update FakeIdBrokerClient to handle `recovery` MFA type
- Re-add `mfa:recovery_input` translation text

### Changed (non-breaking)
- If the user has a `recovery` MFA option, default to asking for that (even before a `manager` MFA option)

---

### Note
- The `Mfa::sendRecoveryCode()` function does not yet use the `$mfaRecoveryContactID` passed to it. That will be addressed in future updates to the tests.

