### PR TITLE
Send recovery contact email address to ID Broker

### DIFF
--- a/features/fakes/FakeIdBrokerClient.php
+++ b/features/fakes/FakeIdBrokerClient.php
@@ -82,11 +82,16 @@ class FakeIdBrokerClient
      * @param string $employee_id
      * @param string $type
      * @param string|null $label
+     * @param string $recoveryEmail
      * @return array|null
      * @throws Exception
      */
-    public function mfaCreate(string $employee_id, string $type, string $label = null): ?array
-    {
+    public function mfaCreate(
+        string $employee_id,
+        string $type,
+        string $label = null,
+        string $recoveryEmail = ''
+    ): ?array {
         if (empty($employee_id)) {
             throw new InvalidArgumentException('employee_id is required');
         }
@@ -117,6 +122,11 @@ class FakeIdBrokerClient
         }
 
         if ($type === 'recovery') {
+            if (empty($recoveryEmail)) {
+                throw new InvalidArgumentException(
+                    'A recoveryEmail is required for MFA recovery codes'
+                );
+            }
             return [
                 "id" => 7890,
                 "data" => [],

--- a/modules/material/themes/material/mfa/send-recovery-mfa.twig
+++ b/modules/material/themes/material/mfa/send-recovery-mfa.twig
@@ -37,9 +37,9 @@
           <p class="mdl-card__subtitle-text">
             {{ '{mfa:recovery_info_selection}'|trans }}<br />
 
-            {% for recoveryContact in recovery_contacts %}
-              <input type="radio" name="mfaRecoveryContactID" value="{{ recoveryContact.name }}">
-              {{ recoveryContact.name }}
+            {% for name in recovery_contacts_by_name|keys %}
+              <input type="radio" name="mfaRecoveryContactID" value="{{ name }}">
+              {{ name }}
               <br />
             {% endfor %}
 

--- a/modules/mfa/public/send-recovery-mfa.php
+++ b/modules/mfa/public/send-recovery-mfa.php
@@ -23,13 +23,14 @@ $state = State::loadState($stateId, Mfa::STAGE_SENT_TO_MFA_PROMPT);
 
 $logger = LoggerFactory::getAccordingToState($state);
 
-$recoveryContacts = Mfa::getRecoveryContacts($state);
+$recoveryContactsByName = Mfa::getRecoveryContactsByName($state);
 
 $errorMessage = null;
 if (filter_has_var(INPUT_POST, 'send')) {
     try {
         $mfaRecoveryContactID = filter_input(INPUT_POST, 'mfaRecoveryContactID');
-        Mfa::sendRecoveryCode($state, $mfaRecoveryContactID, $logger);
+        $recoveryContactEmail = $recoveryContactsByName[$mfaRecoveryContactID];
+        Mfa::sendRecoveryCode($state, $recoveryContactEmail, $logger);
     } catch (Exception $e) {
         $errorMessage = $e->getMessage();
     }
@@ -44,7 +45,7 @@ if (filter_has_var(INPUT_POST, 'send')) {
 $globalConfig = Configuration::getInstance();
 
 $t = new Template($globalConfig, 'mfa:send-recovery-mfa');
-$t->data['recovery_contacts'] = $recoveryContacts;
+$t->data['recovery_contacts_by_name'] = $recoveryContactsByName;
 $t->data['manager_email'] = $state['managerEmail'];
 $t->data['error_message'] = $errorMessage;
 $t->send();

--- a/modules/mfa/src/Auth/Process/Mfa.php
+++ b/modules/mfa/src/Auth/Process/Mfa.php
@@ -959,19 +959,24 @@ class Mfa extends ProcessingFilter
      * If successful, this function triggers a redirect and does not return
      *
      * @param array $state The state data.
-     * @param string $mfaRecoveryContactID The identifier for the selected MFA
-     *     recovery contact.
+     * @param string $recoveryContactEmail The email address for the selected
+     *     MFA recovery contact.
      * @param LoggerInterface $logger A PSR-3 compatible logger.
      * @throws Exception
      */
     public static function sendRecoveryCode(
         array &$state,
-        string $mfaRecoveryContactID,
+        string $recoveryContactEmail,
         LoggerInterface $logger
     ): void {
         try {
             $idBrokerClient = self::getIdBrokerClient($state['idBrokerConfig']);
-            $mfaOption = $idBrokerClient->mfaCreate($state['employeeId'], 'recovery');
+            $mfaOption = $idBrokerClient->mfaCreate(
+                $state['employeeId'],
+                'recovery',
+                'Recovery contact',
+                $recoveryContactEmail
+            );
             $mfaOption['type'] = 'recovery';
 
             $logger->warning(json_encode([


### PR DESCRIPTION
[IDP-1424](https://itse.youtrack.cloud/issue/IDP-1424) Add a "send to my mail admin" option to ssp-base's "mfa" module

---

### WAITING FOR
- #322 

---

### Changed (non-breaking)
- Have the FakeIdBrokerClient `mfaCreate()` require a recovery email for `recovery` MFAs
  * This is because we expect ID Broker to allow such behavior soon. See [IDP-1482](https://itse.youtrack.cloud/issue/IDP-1482).
- Structure the recovery contact data used in the view as name => email

### Fixed
- Pass the selected recovery contact's email to ID Broker's `mfaCreate()`