### PR TITLE
Abbreviate recovery contacts' names in the view

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,10 @@ services:
       PROFILE_URL_FOR_TESTS: http://pwmanager.local/module.php/core/authenticate.php?as=ssp-hub
       ADMIN_PASS: b
       SECRET_SALT: abc123
+      MFA_RECOVERY_CONTACTS_API: "http://api-mock.local/recovery-contacts"
+      MFA_RECOVERY_CONTACTS_API_KEY: "dummy-key"
+      MFA_RECOVERY_CONTACTS_FALLBACK_NAME: "Dummy Name"
+      MFA_RECOVERY_CONTACTS_FALLBACK_EMAIL: "dummy@example.com"
     volumes:
       - ./dockerbuild/run-integration-tests.sh:/data/run-integration-tests.sh
       - ./dockerbuild/run-metadata-tests.sh:/data/run-metadata-tests.sh

--- a/features/mfa-recovery.feature
+++ b/features/mfa-recovery.feature
@@ -27,3 +27,14 @@ Feature: Send a code to an MFA recovery contact
     When I send the code to the recovery contact
     Then I should not see an error message
     And I should see confirmation that the code was sent
+
+  Scenario: Abbreviate recovery contact names
+    Given I use an IDP that is configured to offer MFA recovery-contacts
+    And I provide credentials that have backup codes
+    And the user has a manager email
+    And the recovery-contacts API has at least one contact for that account
+    And I log in
+    When I click the Request Assistance link
+    Then I should see "your manager" as one of the recovery contact options
+    And I should see the abbreviated name of my recovery contact as an option
+    But I should see not see the full name of my recovery contact

--- a/features/mfa-recovery.feature
+++ b/features/mfa-recovery.feature
@@ -36,5 +36,4 @@ Feature: Send a code to an MFA recovery contact
     And I log in
     When I click the Request Assistance link
     Then I should see "your manager" as one of the recovery contact options
-    And I should see the abbreviated name of my recovery contact as an option
-    But I should see not see the full name of my recovery contact
+    And I should see the abbreviated, not full, name of my recovery contact as an option

--- a/modules/mfa/src/Auth/Process/Mfa.php
+++ b/modules/mfa/src/Auth/Process/Mfa.php
@@ -128,10 +128,13 @@ class Mfa extends ProcessingFilter
         }
     }
 
-    private static function abbreviateName(string $name): string
+    public static function abbreviateName(string $name): string
     {
-        // TEMP - to fix later
-        return $name;
+        return preg_replace(
+            '/^(\w)(\w*) (\w+)/',
+            '$1. $3',
+            $name
+        );
     }
 
     /**
@@ -322,9 +325,9 @@ class Mfa extends ProcessingFilter
 
         $recoveryContactsByName = [];
         foreach ($recoveryContactsFromApi as $recoveryContact) {
-            $abbreviatedName = static::abbreviateName($recoveryContact['name']);
+            $name = $recoveryContact['name'];
             $emailAddress = $recoveryContact['email'];
-            $recoveryContactsByName[$abbreviatedName] = $emailAddress;
+            $recoveryContactsByName[$name] = $emailAddress;
         }
 
         if (empty($recoveryContactsByName)) {

--- a/modules/mfa/src/Auth/Process/Mfa.php
+++ b/modules/mfa/src/Auth/Process/Mfa.php
@@ -128,6 +128,15 @@ class Mfa extends ProcessingFilter
         }
     }
 
+    /**
+     * Abbreviate the provided name so that someone who knows them would still
+     * recognize it, but someone who does not know them will hopefully not have
+     * enough information to figure out exactly who it is.
+     *
+     * @param string $name Example: 'John Smith'
+     * @return string Example: 'J. Smith' (though how it is abbreviated may
+     *     change in the future)
+     */
     public static function abbreviateName(string $name): string
     {
         return preg_replace(


### PR DESCRIPTION
[IDP-1424](https://itse.youtrack.cloud/issue/IDP-1424) Add a "send to my mail admin" option to ssp-base's "mfa" module

---

### WAITING FOR
- #323
  * ... or maybe just #322

---

### Added
- Enable the test code to verify what the recovery contacts API returns

### Fixed
- Abbreviate recovery contacts' names in the form shown to the user
- Confirm that recovery contacts' names are shown abbreviated