### PR TITLE
Enable using the new `recovery` MFA flow to send a code to the manager

### DIFF
--- a/features/bootstrap/MfaRecoveryContext.php
+++ b/features/bootstrap/MfaRecoveryContext.php
@@ -106,7 +106,7 @@ class MfaRecoveryContext extends MfaContext
     {
         $page = $this->session->getPage();
         Assert::assertContains(
-            'A temporary code was sent to your recovery contact.',
+            'A temporary code was sent to your recovery contact',
             $page->getContent()
         );
     }

--- a/features/bootstrap/MfaRecoveryContext.php
+++ b/features/bootstrap/MfaRecoveryContext.php
@@ -178,4 +178,13 @@ class MfaRecoveryContext extends MfaContext
             );
         }
     }
+
+    #[When('I send the code to the manager')]
+    public function iSendTheCodeToTheManager(): void
+    {
+        $page = $this->session->getPage();
+        $managerOption = $page->findById('option-manager');
+        $managerOption->click();
+        $page->pressButton('send');
+    }
 }

--- a/features/mfa-recovery.feature
+++ b/features/mfa-recovery.feature
@@ -28,6 +28,16 @@ Feature: Send a code to an MFA recovery contact
     Then I should not see an error message
     And I should see confirmation that the code was sent
 
+  Scenario: User with manager and recovery contact, send code to manager
+    Given I use an IDP that is configured to offer MFA recovery-contacts
+    And I provide credentials that have backup codes
+    And the user has a manager email
+    And I log in
+    And I click the Request Assistance link
+    When I send the code to the manager
+    Then I should not see an error message
+    And I should see confirmation that the code was sent
+
   Scenario: Abbreviate recovery contact names
     Given I use an IDP that is configured to offer MFA recovery-contacts
     And I provide credentials that have backup codes

--- a/modules/material/locales/en/LC_MESSAGES/material.po
+++ b/modules/material/locales/en/LC_MESSAGES/material.po
@@ -159,7 +159,7 @@ msgid "{mfa:manager_info}"
 msgstr "You can send a 2-step verification code to your recovery contact (usually your supervisor). The email we have for your recovery contact is:<br><br><code>%managerEmail%</code><br><br>We've hidden most of the letters for your contact's protection."
 
 msgid "{mfa:manager_sent}"
-msgstr "A temporary code was sent your recovery contact at %managerEmail%."
+msgstr "A temporary code was sent to your recovery contact at %managerEmail%."
 
 msgid "{mfa:manager_input}"
 msgstr "Enter code"

--- a/modules/mfa/public/send-recovery-mfa.php
+++ b/modules/mfa/public/send-recovery-mfa.php
@@ -35,8 +35,12 @@ $errorMessage = null;
 if (filter_has_var(INPUT_POST, 'send')) {
     try {
         $mfaRecoveryContactID = filter_input(INPUT_POST, 'mfaRecoveryContactID');
-        $recoveryContactEmail = $recoveryContactsForView[$mfaRecoveryContactID];
-        Mfa::sendRecoveryCode($state, $recoveryContactEmail, $logger);
+        if ($mfaRecoveryContactID === 'recovery-contact-id-manager') {
+            Mfa::sendManagerCode($state, $logger);
+        } else {
+            $recoveryContactEmail = $recoveryContactsForView[$mfaRecoveryContactID];
+            Mfa::sendRecoveryCode($state, $recoveryContactEmail, $logger);
+        }
     } catch (Exception $e) {
         $errorMessage = $e->getMessage();
     }


### PR DESCRIPTION
### Fixed
- If the user selects "your manager", send a code to their manager
- Make the 'the code was sent' test step match recovery view or manager view
  * We might later switch to using a `recovery` MFA code for both the recovery contacts and the manager (rather than sending a `manager` code to the manager), but for now this gets us to a working version sooner.