### PR TITLE
Fix labels for "use recovery" vs "use manager"

### DIFF
--- a/modules/material/locales/en/LC_MESSAGES/material.po
+++ b/modules/material/locales/en/LC_MESSAGES/material.po
@@ -251,6 +251,9 @@ msgstr "I need help"
 msgid "{mfa:use_manager}"
 msgstr "Use code from my recovery contact"
 
+msgid "{mfa:use_recovery}"
+msgstr "Use code from my recovery contact"
+
 msgid "{mfa:button_verify}"
 msgstr "Verify"
 

--- a/modules/material/locales/en/LC_MESSAGES/material.po
+++ b/modules/material/locales/en/LC_MESSAGES/material.po
@@ -249,7 +249,7 @@ msgid "{mfa:use_help}"
 msgstr "I need help"
 
 msgid "{mfa:use_manager}"
-msgstr "Use code from my recovery contact"
+msgstr "Use code from my supervisor"
 
 msgid "{mfa:use_recovery}"
 msgstr "Use code from my recovery contact"

--- a/modules/material/locales/es/LC_MESSAGES/material.po
+++ b/modules/material/locales/es/LC_MESSAGES/material.po
@@ -251,6 +251,9 @@ msgstr "necesito ayuda"
 msgid "{mfa:use_manager}"
 msgstr "Usar código de mi contacto de recuperación"
 
+msgid "{mfa:use_recovery}"
+msgstr "Usar código de mi contacto de recuperación"
+
 msgid "{mfa:button_verify}"
 msgstr "Verificar"
 

--- a/modules/material/locales/es/LC_MESSAGES/material.po
+++ b/modules/material/locales/es/LC_MESSAGES/material.po
@@ -249,7 +249,7 @@ msgid "{mfa:use_help}"
 msgstr "necesito ayuda"
 
 msgid "{mfa:use_manager}"
-msgstr "Usar código de mi contacto de recuperación"
+msgstr "Usar código de mi supervisor"
 
 msgid "{mfa:use_recovery}"
 msgstr "Usar código de mi contacto de recuperación"

--- a/modules/material/locales/fr/LC_MESSAGES/material.po
+++ b/modules/material/locales/fr/LC_MESSAGES/material.po
@@ -251,6 +251,9 @@ msgstr "j'ai besoin d'aide"
 msgid "{mfa:use_manager}"
 msgstr "Utiliser le code de mon contact de récupération"
 
+msgid "{mfa:use_recovery}"
+msgstr "Utiliser le code de mon contact de récupération"
+
 msgid "{mfa:button_verify}"
 msgstr "Vérifier"
 

--- a/modules/material/locales/fr/LC_MESSAGES/material.po
+++ b/modules/material/locales/fr/LC_MESSAGES/material.po
@@ -249,7 +249,7 @@ msgid "{mfa:use_help}"
 msgstr "j'ai besoin d'aide"
 
 msgid "{mfa:use_manager}"
-msgstr "Utiliser le code de mon contact de récupération"
+msgstr "Utiliser le code de mon superviseur"
 
 msgid "{mfa:use_recovery}"
 msgstr "Utiliser le code de mon contact de récupération"

--- a/modules/material/locales/ko/LC_MESSAGES/material.po
+++ b/modules/material/locales/ko/LC_MESSAGES/material.po
@@ -249,7 +249,7 @@ msgid "{mfa:use_help}"
 msgstr "도움이 필요해."
 
 msgid "{mfa:use_manager}"
-msgstr "복구 담당자의 코드 사용"
+msgstr "내 상사의 코드를 사용하세요"
 
 msgid "{mfa:use_recovery}"
 msgstr "복구 담당자의 코드 사용"

--- a/modules/material/locales/ko/LC_MESSAGES/material.po
+++ b/modules/material/locales/ko/LC_MESSAGES/material.po
@@ -251,6 +251,9 @@ msgstr "도움이 필요해."
 msgid "{mfa:use_manager}"
 msgstr "복구 담당자의 코드 사용"
 
+msgid "{mfa:use_recovery}"
+msgstr "복구 담당자의 코드 사용"
+
 msgid "{mfa:button_verify}"
 msgstr "검증"
 


### PR DESCRIPTION
### Fixed
- Add missing `mfa:use_recovery` string and translations
- Modify the `mfa:use_manager` translations, to differ from `mfa:use_recovery`
    * I'm concerned that the Korean translation changed more than just the "recovery contact" to "supervisor" part, since the new text is so different. It seems to now have a different level of formality (e.g. it now seems to say the equivalent of "Please use..." instead of "Use..."). I don't know enough about Korean to verify or fix that, though.