### PR TITLE
Help user know which manager it is (in the recovery-contacts list)

### DIFF
--- a/modules/material/themes/material/mfa/send-recovery-mfa.twig
+++ b/modules/material/themes/material/mfa/send-recovery-mfa.twig
@@ -43,9 +43,9 @@
               <br />
             {% endfor %}
 
-            {% if manager_email is not empty %}
+            {% if masked_manager_email is not empty %}
               <input type="radio" name="mfaRecoveryContactID" id="option-manager" value="recovery-contact-id-manager">
-              {{ '{mfa:recovery_your_supervisor}'|trans }} ({{ manager_email }})
+              {{ '{mfa:recovery_your_supervisor}'|trans }} ({{ masked_manager_email }})
               <br />
             {% endif %}
           </p>

--- a/modules/material/themes/material/mfa/send-recovery-mfa.twig
+++ b/modules/material/themes/material/mfa/send-recovery-mfa.twig
@@ -45,7 +45,7 @@
 
             {% if manager_email is not empty %}
               <input type="radio" name="mfaRecoveryContactID" id="option-manager" value="recovery-contact-id-manager">
-              {{ '{mfa:recovery_your_supervisor}'|trans }}
+              {{ '{mfa:recovery_your_supervisor}'|trans }} ({{ manager_email }})
               <br />
             {% endif %}
           </p>

--- a/modules/mfa/public/send-recovery-mfa.php
+++ b/modules/mfa/public/send-recovery-mfa.php
@@ -63,7 +63,7 @@ $globalConfig = Configuration::getInstance();
 
 $t = new Template($globalConfig, 'mfa:send-recovery-mfa');
 $t->data['recovery_contacts_by_name'] = $recoveryContactsForView;
-$t->data['manager_email'] = $state['managerEmail'];
+$t->data['masked_manager_email'] = $state['managerEmail'];
 $t->data['error_message'] = $errorMessage;
 $t->send();
 


### PR DESCRIPTION
[IDP-1536](https://itse.youtrack.cloud/issue/IDP-1536) Include the masked manager email address after "your supervisor" when selecting a recovery contact

---

### Fixed
- Show the (masked) manager email to help identify which supervisor
- Rename view's variable to clarify that it is the masked manager email