### PR TITLE
Rename masked-manager-email variables for clarity/accuracy

### DIFF
--- a/modules/material/locales/en/LC_MESSAGES/material.po
+++ b/modules/material/locales/en/LC_MESSAGES/material.po
@@ -159,7 +159,7 @@ msgid "{mfa:manager_info}"
 msgstr "You can send a 2-step verification code to your recovery contact (usually your supervisor). The email we have for your recovery contact is:<br><br><code>%managerEmail%</code><br><br>We've hidden most of the letters for your contact's protection."
 
 msgid "{mfa:manager_sent}"
-msgstr "A temporary code was sent to your recovery contact at %managerEmail%."
+msgstr "A temporary code was sent to your recovery contact at %maskedManagerEmail%."
 
 msgid "{mfa:manager_input}"
 msgstr "Enter code"

--- a/modules/material/locales/en/LC_MESSAGES/material.po
+++ b/modules/material/locales/en/LC_MESSAGES/material.po
@@ -156,7 +156,7 @@ msgid "{mfa:manager_header}"
 msgstr "Ask Your Recovery Contact for Help"
 
 msgid "{mfa:manager_info}"
-msgstr "You can send a 2-step verification code to your recovery contact (usually your supervisor). The email we have for your recovery contact is:<br><br><code>%managerEmail%</code><br><br>We've hidden most of the letters for your contact's protection."
+msgstr "You can send a 2-step verification code to your recovery contact (usually your supervisor). The email we have for your recovery contact is:<br><br><code>%maskedManagerEmail%</code><br><br>We've hidden most of the letters for your contact's protection."
 
 msgid "{mfa:manager_sent}"
 msgstr "A temporary code was sent to your recovery contact at %maskedManagerEmail%."

--- a/modules/material/locales/es/LC_MESSAGES/material.po
+++ b/modules/material/locales/es/LC_MESSAGES/material.po
@@ -159,7 +159,7 @@ msgid "{mfa:manager_info}"
 msgstr "Puede enviar un código de verificación de dos pasos a su contacto de recuperación (normalmente su supervisor). La dirección de correo electrónico que tenemos para su contacto de recuperación es:<br><br><code>%managerEmail%</code><br><br>Ocultamos la mayoría de las letras para proteger a su contacto."
 
 msgid "{mfa:manager_sent}"
-msgstr "Se envió un código temporal a su contacto de recuperación en %managerEmail%."
+msgstr "Se envió un código temporal a su contacto de recuperación en %maskedManagerEmail%."
 
 msgid "{mfa:manager_input}"
 msgstr "Introduzca el código"

--- a/modules/material/locales/es/LC_MESSAGES/material.po
+++ b/modules/material/locales/es/LC_MESSAGES/material.po
@@ -156,7 +156,7 @@ msgid "{mfa:manager_header}"
 msgstr "Pida ayuda de contacto de recuperación"
 
 msgid "{mfa:manager_info}"
-msgstr "Puede enviar un código de verificación de dos pasos a su contacto de recuperación (normalmente su supervisor). La dirección de correo electrónico que tenemos para su contacto de recuperación es:<br><br><code>%managerEmail%</code><br><br>Ocultamos la mayoría de las letras para proteger a su contacto."
+msgstr "Puede enviar un código de verificación de dos pasos a su contacto de recuperación (normalmente su supervisor). La dirección de correo electrónico que tenemos para su contacto de recuperación es:<br><br><code>%maskedManagerEmail%</code><br><br>Ocultamos la mayoría de las letras para proteger a su contacto."
 
 msgid "{mfa:manager_sent}"
 msgstr "Se envió un código temporal a su contacto de recuperación en %maskedManagerEmail%."

--- a/modules/material/locales/fr/LC_MESSAGES/material.po
+++ b/modules/material/locales/fr/LC_MESSAGES/material.po
@@ -156,7 +156,7 @@ msgid "{mfa:manager_header}"
 msgstr "Demandez de l'aide à votre contact de récupération"
 
 msgid "{mfa:manager_info}"
-msgstr "Vous pouvez envoyer un code de vérification en deux étapes à votre contact de récupération (en général votre superviseur). L'adresse électronique que nous avons pour votre contact de récupération est:<br><br><code>%managerEmail%</code><br><br>. Nous avons caché la plupart des lettres pour la protection de votre contact."
+msgstr "Vous pouvez envoyer un code de vérification en deux étapes à votre contact de récupération (en général votre superviseur). L'adresse électronique que nous avons pour votre contact de récupération est:<br><br><code>%maskedManagerEmail%</code><br><br>. Nous avons caché la plupart des lettres pour la protection de votre contact."
 
 msgid "{mfa:manager_sent}"
 msgstr "Un code temporaire a été envoyé à votre contact de récupération à l'adresse %maskedManagerEmail%."

--- a/modules/material/locales/fr/LC_MESSAGES/material.po
+++ b/modules/material/locales/fr/LC_MESSAGES/material.po
@@ -159,7 +159,7 @@ msgid "{mfa:manager_info}"
 msgstr "Vous pouvez envoyer un code de vérification en deux étapes à votre contact de récupération (en général votre superviseur). L'adresse électronique que nous avons pour votre contact de récupération est:<br><br><code>%managerEmail%</code><br><br>. Nous avons caché la plupart des lettres pour la protection de votre contact."
 
 msgid "{mfa:manager_sent}"
-msgstr "Un code temporaire a été envoyé à votre contact de récupération à l'adresse %managerEmail%."
+msgstr "Un code temporaire a été envoyé à votre contact de récupération à l'adresse %maskedManagerEmail%."
 
 msgid "{mfa:manager_input}"
 msgstr "Entrer le code"

--- a/modules/material/locales/ko/LC_MESSAGES/material.po
+++ b/modules/material/locales/ko/LC_MESSAGES/material.po
@@ -156,7 +156,7 @@ msgid "{mfa:manager_header}"
 msgstr "복구 담당자에게 도움을 요청하십시오"
 
 msgid "{mfa:manager_info}"
-msgstr "2단계 인증 코드를 복구 연락처(보통 상사)에게 보낼 수 있습니다. 복구 연락처에 대한 이메일은 다음과 같습니다. <br><br><code>%managerEmail%</code><br><br> 연락처 보호를 위해 대부분의 편지를 숨겼습니다."
+msgstr "2단계 인증 코드를 복구 연락처(보통 상사)에게 보낼 수 있습니다. 복구 연락처에 대한 이메일은 다음과 같습니다. <br><br><code>%maskedManagerEmail%</code><br><br> 연락처 보호를 위해 대부분의 편지를 숨겼습니다."
 
 msgid "{mfa:manager_sent}"
 msgstr "%maskedManagerEmail% (으)로 복구 담당자에게 임시 코드를 보냈습니다."

--- a/modules/material/locales/ko/LC_MESSAGES/material.po
+++ b/modules/material/locales/ko/LC_MESSAGES/material.po
@@ -159,7 +159,7 @@ msgid "{mfa:manager_info}"
 msgstr "2단계 인증 코드를 복구 연락처(보통 상사)에게 보낼 수 있습니다. 복구 연락처에 대한 이메일은 다음과 같습니다. <br><br><code>%managerEmail%</code><br><br> 연락처 보호를 위해 대부분의 편지를 숨겼습니다."
 
 msgid "{mfa:manager_sent}"
-msgstr "%managerEmail% (으)로 복구 담당자에게 임시 코드를 보냈습니다."
+msgstr "%maskedManagerEmail% (으)로 복구 담당자에게 임시 코드를 보냈습니다."
 
 msgid "{mfa:manager_input}"
 msgstr "코드 입력"

--- a/modules/material/themes/material/mfa/prompt-for-mfa-manager.twig
+++ b/modules/material/themes/material/mfa/prompt-for-mfa-manager.twig
@@ -31,7 +31,7 @@
 
         <div class="mdl-card__title center">
           <p class="mdl-card__subtitle-text">
-            {{ '{mfa:manager_sent}'|trans({'%managerEmail%': manager_email}) }}
+            {{ '{mfa:manager_sent}'|trans({'%managerEmail%': masked_manager_email}) }}
           </p>
         </div>
 

--- a/modules/material/themes/material/mfa/prompt-for-mfa-manager.twig
+++ b/modules/material/themes/material/mfa/prompt-for-mfa-manager.twig
@@ -31,7 +31,7 @@
 
         <div class="mdl-card__title center">
           <p class="mdl-card__subtitle-text">
-            {{ '{mfa:manager_sent}'|trans({'%managerEmail%': masked_manager_email}) }}
+            {{ '{mfa:manager_sent}'|trans({'%maskedManagerEmail%': masked_manager_email}) }}
           </p>
         </div>
 

--- a/modules/material/themes/material/mfa/send-manager-mfa.twig
+++ b/modules/material/themes/material/mfa/send-manager-mfa.twig
@@ -29,7 +29,7 @@
 
         <div class="mdl-card__title center">
           <p class="mdl-card__subtitle-text">
-            {{ '{mfa:manager_info}'|trans({'%managerEmail%': masked_manager_email})|raw }}
+            {{ '{mfa:manager_info}'|trans({'%maskedManagerEmail%': masked_manager_email})|raw }}
           </p>
         </div>
 

--- a/modules/material/themes/material/mfa/send-manager-mfa.twig
+++ b/modules/material/themes/material/mfa/send-manager-mfa.twig
@@ -29,7 +29,7 @@
 
         <div class="mdl-card__title center">
           <p class="mdl-card__subtitle-text">
-            {{ '{mfa:manager_info}'|trans({'%managerEmail%': manager_email})|raw }}
+            {{ '{mfa:manager_info}'|trans({'%managerEmail%': masked_manager_email})|raw }}
           </p>
         </div>
 

--- a/modules/mfa/public/prompt-for-mfa.php
+++ b/modules/mfa/public/prompt-for-mfa.php
@@ -113,7 +113,7 @@ if (!empty($recoveryContactsApi)) {
         'type' => 'manager',
         'callback' => '/module.php/mfa/send-recovery-mfa.php?StateId=' . htmlentities($stateId)
     ];
-} elseif (!empty($state['managerEmail'])) {
+} elseif (!empty($state['maskedManagerEmail'])) {
     $otherOptions[] = [
         'type' => 'manager',
         'callback' => '/module.php/mfa/send-manager-mfa.php?StateId=' . htmlentities($stateId)
@@ -139,7 +139,7 @@ $t->data['mfa_options'] = $mfaOptions;
 $browserJsHash = md5_file(__DIR__ . '/simplewebauthn/browser.js');
 $t->data['browser_js_path'] = '/module.php/mfa/simplewebauthn/browser.js?v=' . $browserJsHash;
 $t->data['remember_me_js_path'] = '/module.php/mfa/remember-me.js';
-$t->data['manager_email'] = $state['managerEmail'];
+$t->data['manager_email'] = $state['maskedManagerEmail'];
 $t->data['other_options'] = $otherOptions;
 $t->data['idp_name'] = $t->getEntityDisplayName($state['IdPMetadata']);
 $t->data['rememberMePreference'] = filter_input(INPUT_COOKIE, 'remember_me_preference') ?? '';

--- a/modules/mfa/public/prompt-for-mfa.php
+++ b/modules/mfa/public/prompt-for-mfa.php
@@ -139,7 +139,7 @@ $t->data['mfa_options'] = $mfaOptions;
 $browserJsHash = md5_file(__DIR__ . '/simplewebauthn/browser.js');
 $t->data['browser_js_path'] = '/module.php/mfa/simplewebauthn/browser.js?v=' . $browserJsHash;
 $t->data['remember_me_js_path'] = '/module.php/mfa/remember-me.js';
-$t->data['manager_email'] = $state['maskedManagerEmail'];
+$t->data['masked_manager_email'] = $state['maskedManagerEmail'];
 $t->data['other_options'] = $otherOptions;
 $t->data['idp_name'] = $t->getEntityDisplayName($state['IdPMetadata']);
 $t->data['rememberMePreference'] = filter_input(INPUT_COOKIE, 'remember_me_preference') ?? '';

--- a/modules/mfa/public/send-manager-mfa.php
+++ b/modules/mfa/public/send-manager-mfa.php
@@ -41,7 +41,7 @@ if (filter_has_var(INPUT_POST, 'send')) {
 $globalConfig = Configuration::getInstance();
 
 $t = new Template($globalConfig, 'mfa:send-manager-mfa');
-$t->data['manager_email'] = $state['maskedManagerEmail'];
+$t->data['masked_manager_email'] = $state['maskedManagerEmail'];
 $t->data['error_message'] = $errorMessage;
 $t->send();
 

--- a/modules/mfa/public/send-manager-mfa.php
+++ b/modules/mfa/public/send-manager-mfa.php
@@ -41,7 +41,7 @@ if (filter_has_var(INPUT_POST, 'send')) {
 $globalConfig = Configuration::getInstance();
 
 $t = new Template($globalConfig, 'mfa:send-manager-mfa');
-$t->data['manager_email'] = $state['managerEmail'];
+$t->data['manager_email'] = $state['maskedManagerEmail'];
 $t->data['error_message'] = $errorMessage;
 $t->send();
 

--- a/modules/mfa/public/send-recovery-mfa.php
+++ b/modules/mfa/public/send-recovery-mfa.php
@@ -63,7 +63,7 @@ $globalConfig = Configuration::getInstance();
 
 $t = new Template($globalConfig, 'mfa:send-recovery-mfa');
 $t->data['recovery_contacts_by_name'] = $recoveryContactsForView;
-$t->data['masked_manager_email'] = $state['managerEmail'];
+$t->data['masked_manager_email'] = $state['maskedManagerEmail'];
 $t->data['error_message'] = $errorMessage;
 $t->send();
 

--- a/modules/mfa/src/Auth/Process/Mfa.php
+++ b/modules/mfa/src/Auth/Process/Mfa.php
@@ -718,7 +718,7 @@ class Mfa extends ProcessingFilter
         /** @todo Check for valid remember-me cookies here rather doing a redirect first. */
 
         $state['mfaOptions'] = $mfaOptions;
-        $state['managerEmail'] = self::getMaskedManagerEmail($state);
+        $state['maskedManagerEmail'] = self::getMaskedManagerEmail($state);
         $state['unmaskedManagerEmail'] = self::getManagerEmail($state);
         $state['idBrokerConfig'] = [
             'accessToken' => $this->idBrokerAccessToken,
@@ -950,7 +950,7 @@ class Mfa extends ProcessingFilter
          */
         $mfaOptions['manager'] = $mfaOption;
         $state['mfaOptions'] = $mfaOptions;
-        $state['managerEmail'] = self::getMaskedManagerEmail($state);
+        $state['maskedManagerEmail'] = self::getMaskedManagerEmail($state);
         $stateId = State::saveState($state, self::STAGE_SENT_TO_MFA_PROMPT);
 
         $url = Module::getModuleURL('mfa/prompt-for-mfa.php');

--- a/modules/mfa/src/Auth/Process/Mfa.php
+++ b/modules/mfa/src/Auth/Process/Mfa.php
@@ -1037,7 +1037,7 @@ class Mfa extends ProcessingFilter
     }
 
     /**
-     * Get masked copy of manager_email, or null if it isn't available.
+     * Get manager_email, or null if it isn't available.
      *
      * @param array $state
      * @return string|null


### PR DESCRIPTION
### WAITING FOR
- #340 

---

### Fixed
- Rename `$state['managerEmail']` to `$state['maskedManagerEmail']`
- Rename `manager_email` to `masked_manager_email` in MFA view parameters 
- Rename (masked) manager email key in `mfa:manager_sent` translations
- Rename (masked) manager email key in `mfa:manager_info` translations
- Fix copy/paste mistake in `getManagerEmail()` function description