### PR TITLE
Adjust log levels for MFA-recovery option page loads

### DIFF
--- a/modules/mfa/public/send-manager-mfa.php
+++ b/modules/mfa/public/send-manager-mfa.php
@@ -45,7 +45,7 @@ $t->data['masked_manager_email'] = $state['maskedManagerEmail'];
 $t->data['error_message'] = $errorMessage;
 $t->send();
 
-$logger->info(json_encode([
+$logger->notice(json_encode([
     'event' => 'offer to send manager code',
     'employeeId' => $state['employeeId'],
 ]));

--- a/modules/mfa/public/send-recovery-mfa.php
+++ b/modules/mfa/public/send-recovery-mfa.php
@@ -67,7 +67,7 @@ $t->data['masked_manager_email'] = $state['maskedManagerEmail'];
 $t->data['error_message'] = $errorMessage;
 $t->send();
 
-$logger->info(json_encode([
+$logger->notice(json_encode([
     'event' => 'offer to send recovery code',
     'employeeId' => $state['employeeId'],
     'contactsFromApi' => $recoveryContactsFromApi,


### PR DESCRIPTION
### Fixed
- Adjust recovery-options-offered log message level to Notice 
  * "Notice" is for "Normal but significant events", and is included in our logs by default. "Info" level logs are not, and this seems like more than merely an info-level log event.
- Similarly log manager-mfa-code-offered message as Notice level 
  * This seems comparable to the recovery-options-offered message, so I am setting it to have the same log level.