### PR TITLE
add --non-unique to useradd to resolve conflict if local user id is 1000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN <<EOT
     composer self-update --no-interaction
 
     groupadd -g "$GID" user
-    useradd -m -u "$UID" -g "$GID" user
+    useradd --create-home --uid "$UID" --gid "$GID" --non-unique user
     mkdir -p /var/run/apache2 /var/lock/apache2 /var/log/apache2
     chown -R user:user /var/run/apache2 /var/lock/apache2 /var/log/apache2 /var/www/html
 EOT


### PR DESCRIPTION
### Fixed
- In the Dockerfile, add the `--non-unique` flag to the `useradd` command. This avoids a conflict when the local user ID is 1000, which is the `ubuntu` user in the base Docker image.