### PR TITLE
fix flaky tests

### DIFF
--- a/features/bootstrap/ExpiryContext.php
+++ b/features/bootstrap/ExpiryContext.php
@@ -1,7 +1,6 @@
 <?php
 
 use Behat\Mink\Element\DocumentElement;
-use Behat\Mink\Session;
 use PHPUnit\Framework\Assert;
 
 /**
@@ -9,14 +8,6 @@ use PHPUnit\Framework\Assert;
  */
 class ExpiryContext extends FeatureContext
 {
-    /**
-     * The browser session, used for interacting with the website.
-     *
-     * @var Session
-     */
-    protected $session;
-
-
     /**
      * Assert that the given page has a form that contains the given text.
      *

--- a/features/bootstrap/ExpiryContext.php
+++ b/features/bootstrap/ExpiryContext.php
@@ -1,7 +1,6 @@
 <?php
 
 use Behat\Mink\Element\DocumentElement;
-use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Session;
 use PHPUnit\Framework\Assert;
 
@@ -87,7 +86,7 @@ class ExpiryContext extends FeatureContext
      */
     public function iShouldSeeAWarningThatMyPasswordWillExpireSoon()
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         Assert::assertContains('will expire', $page->getHtml());
     }
 
@@ -96,7 +95,7 @@ class ExpiryContext extends FeatureContext
      */
     public function thereShouldBeAWayToGoChangeMyPasswordNow()
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $this->assertFormContains('change', $page);
     }
 
@@ -105,7 +104,7 @@ class ExpiryContext extends FeatureContext
      */
     public function thereShouldBeAWayToContinueWithoutChangingMyPassword()
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $this->assertFormContains('continue', $page);
     }
 
@@ -124,7 +123,7 @@ class ExpiryContext extends FeatureContext
      */
     public function iShouldSeeAMessageThatMyPasswordHasExpired()
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         Assert::assertContains('has expired', $page->getHtml());
     }
 
@@ -133,7 +132,7 @@ class ExpiryContext extends FeatureContext
      */
     public function thereShouldNotBeAWayToContinueWithoutChangingMyPassword()
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $this->assertFormNotContains('continue', $page);
     }
 
@@ -152,7 +151,7 @@ class ExpiryContext extends FeatureContext
      */
     public function iShouldSeeAnErrorMessage()
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         Assert::assertContains('We could not understand the expiration date', $page->getHtml());
     }
 

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -309,7 +309,6 @@ class FeatureContext extends MinkContext
         ));
         Assert::notNull($button, 'Failed to find button named ' . $buttonName);
         $button->click();
-        $this->submitSecondarySspFormIfPresent($page);
     }
 
     /**
@@ -322,32 +321,6 @@ class FeatureContext extends MinkContext
     {
         $loginButton = $this->getLoginButton($page);
         $loginButton->click();
-        $this->submitSecondarySspFormIfPresent($page);
-    }
-
-    /**
-     * Submit the secondary page's form (if simpleSAMLphp shows another page
-     * because JavaScript isn't supported).
-     *
-     * @param DocumentElement $page The page.
-     */
-    protected function submitSecondarySspFormIfPresent($page)
-    {
-        // SimpleSAMLphp 1.15 markup for secondary page:
-        $postLoginSubmitButton = $page->findButton('postLoginSubmitButton');
-        if ($postLoginSubmitButton instanceof NodeElement) {
-            $postLoginSubmitButton->click();
-        } else {
-
-            // SimpleSAMLphp 1.14 markup for secondary page:
-            $body = $page->find('css', 'body');
-            if ($body instanceof NodeElement) {
-                $onload = $body->getAttribute('onload');
-                if ($onload === "document.getElementsByTagName('input')[0].click();") {
-                    $body->pressButton('Submit');
-                }
-            }
-        }
     }
 
     /**

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -192,7 +192,7 @@ class FeatureContext extends MinkContext
         $session = $this->getSession();
         $page = $session->getPage();
 
-// Wait until the new page body contains the expected text (escape for JS string literal).
+        // Wait until the new page body contains the expected text (escape for JS string literal).
         $expectedJs = json_encode($expectedText, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
 
         $session->wait(5000, <<<JS
@@ -341,7 +341,7 @@ JS);
     {
         $expectedPath = json_encode('module.php/core/welcome', JSON_UNESCAPED_SLASHES);
         $session = $this->getSession();
-        $session->wait(10000, <<<JS
+        $session->wait(1000, <<<JS
   document.readyState === "complete"
   && window.location
   && window.location.href.endsWith($expectedPath)

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -306,6 +306,7 @@ class FeatureContext extends MinkContext
         ));
         Assert::notNull($button, 'Failed to find button named ' . $buttonName);
         $button->click();
+        $this->getSession()->wait(5000, 'document.readyState === "complete"');
     }
 
     /**

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -47,7 +47,6 @@ class FeatureContext extends MinkContext
             $this->showPageDetails();
             $this->takeScreenshot();
         }
-        $this->getSession()->wait(100);
     }
 
     /**

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -47,6 +47,7 @@ class FeatureContext extends MinkContext
             $this->showPageDetails();
             $this->takeScreenshot();
         }
+        $this->getSession()->wait(100);
     }
 
     /**

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -157,6 +157,13 @@ class FeatureContext extends MinkContext
      */
     public function iClickOnTheTile($idpName)
     {
+        $expectedPath = json_encode('module.php/sildisco/disco', JSON_UNESCAPED_SLASHES);
+        Assert::true($this->getSession()->wait(1000, <<<JS
+  document.readyState === "complete"
+  && window.location
+  && window.location.href.includes($expectedPath)
+JS), 'Did not reach the discovery page');
+
         $page = $this->getSession()->getPage();
         $idpTileTitle = sprintf('%s Sign in', $idpName);
         $idpTile = $page->find(

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -127,7 +127,6 @@ class FeatureContext extends MinkContext
         $this->fillField('username', $username);
         $this->fillField('password', $password);
         $this->pressButton('Login');
-        $this->getSession()->wait(5000, 'document.readyState === "complete"');
     }
 
     /**
@@ -321,7 +320,6 @@ JS);
         ));
         Assert::notNull($button, 'Failed to find button named ' . $buttonName);
         $button->click();
-        $this->getSession()->wait(5000, 'document.readyState === "complete"');
     }
 
     /**
@@ -334,7 +332,6 @@ JS);
     {
         $loginButton = $this->getLoginButton($page);
         $loginButton->click();
-        $this->getSession()->wait(5000, 'document.readyState === "complete"');
     }
 
     /**

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -195,7 +195,7 @@ class FeatureContext extends MinkContext
         // Wait until the new page body contains the expected text (escape for JS string literal).
         $expectedJs = json_encode($expectedText, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
 
-        $session->wait(5000, <<<JS
+        $session->wait(1000, <<<JS
   document.readyState === "complete"
   && document.body
   && document.body.innerText
@@ -341,11 +341,11 @@ JS);
     {
         $expectedPath = json_encode('module.php/core/welcome', JSON_UNESCAPED_SLASHES);
         $session = $this->getSession();
-        $session->wait(1000, <<<JS
+        Assert::true($session->wait(1000, <<<JS
   document.readyState === "complete"
   && window.location
   && window.location.href.endsWith($expectedPath)
-JS);
+JS), 'Did not reach the welcome page');
 
         $this->assertPageBodyContainsText('not much to see here.');
     }

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -127,6 +127,7 @@ class FeatureContext extends MinkContext
         $this->fillField('username', $username);
         $this->fillField('password', $password);
         $this->pressButton('Login');
+        $this->getSession()->wait(5000, 'document.readyState === "complete"');
     }
 
     /**
@@ -189,9 +190,13 @@ class FeatureContext extends MinkContext
 
     protected function assertPageBodyContainsText(string $expectedText)
     {
+        print "assertPageBodyContainsText: " . $expectedText . "\n";
         $page = $this->getSession()->getPage();
+        print "page\n";
         $body = $page->find('css', 'body');
+        print "body\n";
         Assert::contains($body->getText(), $expectedText);
+        print "pass";
     }
 
     private static function ensureFolderExistsForTestFile($filePath)
@@ -319,6 +324,7 @@ class FeatureContext extends MinkContext
     {
         $loginButton = $this->getLoginButton($page);
         $loginButton->click();
+        $this->getSession()->wait(5000, 'document.readyState === "complete"');
     }
 
     /**

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -23,21 +23,18 @@ class FeatureContext extends MinkContext
 
     const SCREENSHOTS_PATH = '/data/features/screenshots/';
 
-    /** @var Session */
-    protected $session;
-
     protected $username = null;
     protected $password = null;
 
     public function __construct()
     {
         $driver = new ChromeDriver('http://test-browser:9222', null, 'http://ssp-hub.local');
-        $this->session = new Session($driver);
-        $mink = new Mink(['default' => $this->session]);
+        $session = new Session($driver);
+        $mink = new Mink(['default' => $session]);
         $mink->setDefaultSessionName('default');
         $this->setMink($mink);
         // See http://mink.behat.org/en/latest/guides/session.html for docs.
-        $this->session->start();
+        $session->start();
     }
 
     /** @AfterStep */
@@ -67,7 +64,7 @@ class FeatureContext extends MinkContext
 
     protected function showPageDetails()
     {
-        echo '[' . $this->session->getStatusCode() . '] ';
+        echo '[' . $this->getSession()->getStatusCode() . '] ';
         $this->printLastResponse();
     }
 
@@ -84,7 +81,7 @@ class FeatureContext extends MinkContext
      */
     public function iShouldSeeOurMaterialTheme()
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $hasMaterialDesignElement = $page->has('css', '.mdl-layout');
         Assert::true(
             $hasMaterialDesignElement,
@@ -145,7 +142,7 @@ class FeatureContext extends MinkContext
      */
     public function iShouldSeeAPage($title)
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $titleElement = $page->find('css', 'head > title');
         Assert::notNull($titleElement, "Could not find the page's title");
         Assert::same(
@@ -160,7 +157,7 @@ class FeatureContext extends MinkContext
      */
     public function iClickOnTheTile($idpName)
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $idpTileTitle = sprintf('%s Sign in', $idpName);
         $idpTile = $page->find(
             'css',
@@ -192,7 +189,7 @@ class FeatureContext extends MinkContext
 
     protected function assertPageBodyContainsText(string $expectedText)
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $body = $page->find('css', 'body');
         Assert::contains($body->getText(), $expectedText);
     }
@@ -271,7 +268,7 @@ class FeatureContext extends MinkContext
      */
     public function iLogIn()
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         try {
             $page->fillField('username', $this->username);
             $page->fillField('password', $this->password);
@@ -302,7 +299,7 @@ class FeatureContext extends MinkContext
      */
     protected function submitFormByClickingButtonNamed($buttonName)
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $button = $page->find('css', sprintf(
             '[name=%s]',
             $buttonName

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -157,12 +157,7 @@ class FeatureContext extends MinkContext
      */
     public function iClickOnTheTile($idpName)
     {
-        $expectedPath = json_encode('module.php/sildisco/disco', JSON_UNESCAPED_SLASHES);
-        Assert::true($this->getSession()->wait(1000, <<<JS
-  document.readyState === "complete"
-  && window.location
-  && window.location.href.includes($expectedPath)
-JS), 'Did not reach the discovery page');
+        $this->waitForPage('module.php/sildisco/disco');
 
         $page = $this->getSession()->getPage();
         $idpTileTitle = sprintf('%s Sign in', $idpName);
@@ -346,14 +341,18 @@ JS);
      */
     public function iShouldEndUpAtMyIntendedDestination()
     {
-        $expectedPath = json_encode('module.php/core/welcome', JSON_UNESCAPED_SLASHES);
-        $session = $this->getSession();
-        Assert::true($session->wait(1000, <<<JS
-  document.readyState === "complete"
-  && window.location
-  && window.location.href.endsWith($expectedPath)
-JS), 'Did not reach the welcome page');
+        $this->waitForPage('module.php/core/welcome');
 
         $this->assertPageBodyContainsText('not much to see here.');
+    }
+
+    protected function waitForPage(string $path)
+    {
+        $jsPath = json_encode($path, JSON_UNESCAPED_SLASHES);
+        Assert::true($this->getSession()->wait(1000, <<<JS
+  document.readyState === "complete"
+  && window.location
+  && window.location.href.includes($jsPath)
+JS), "Did not reach the $path page");
     }
 }

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -190,13 +190,23 @@ class FeatureContext extends MinkContext
 
     protected function assertPageBodyContainsText(string $expectedText)
     {
-        print "assertPageBodyContainsText: " . $expectedText . "\n";
-        $page = $this->getSession()->getPage();
-        print "page\n";
+        $session = $this->getSession();
+        $page = $session->getPage();
+
+// Wait until the new page body contains the expected text (escape for JS string literal).
+        $expectedJs = json_encode($expectedText, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        $session->wait(5000, <<<JS
+  document.readyState === "complete"
+  && document.body
+  && document.body.innerText
+  && document.body.innerText.indexOf($expectedJs) !== -1
+JS);
+
+        // Now do the normal assertion (gives better failure output if it still fails)
         $body = $page->find('css', 'body');
-        print "body\n";
+        Assert::notNull($body, 'Could not find <body> element');
         Assert::contains($body->getText(), $expectedText);
-        print "pass";
     }
 
     private static function ensureFolderExistsForTestFile($filePath)

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -342,6 +342,14 @@ JS);
      */
     public function iShouldEndUpAtMyIntendedDestination()
     {
+        $expectedPath = json_encode('module.php/core/welcome', JSON_UNESCAPED_SLASHES);
+        $session = $this->getSession();
+        $session->wait(10000, <<<JS
+  document.readyState === "complete"
+  && window.location
+  && window.location.href.endsWith($expectedPath)
+JS);
+
         $this->assertPageBodyContainsText('not much to see here.');
     }
 }

--- a/features/bootstrap/LastLoginContext.php
+++ b/features/bootstrap/LastLoginContext.php
@@ -28,7 +28,7 @@ class LastLoginContext extends FeatureContext
         $this->password = self::BAD_PASSWORD;
         $this->iLogIn();
 
-        $pageText = $this->session->getPage()->getText();
+        $pageText = $this->getSession()->getPage()->getText();
         Assert::assertTrue(
             stripos($pageText, 'invalid login') !== false
             || stripos($pageText, 'incorrect') !== false

--- a/features/bootstrap/MfaContext.php
+++ b/features/bootstrap/MfaContext.php
@@ -68,7 +68,7 @@ class MfaContext extends FeatureContext
      */
     protected function submitFormByClickingButtonNamed($buttonName)
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $button = $page->find('css', sprintf(
             '[name=%s]',
             $buttonName
@@ -114,7 +114,7 @@ class MfaContext extends FeatureContext
      */
     public function iShouldSeeAMessageThatIHaveToSetUpMfa()
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         Assert::assertContains('must set up 2-', $page->getHtml());
     }
 
@@ -123,7 +123,7 @@ class MfaContext extends FeatureContext
      */
     public function thereShouldBeAWayToGoSetUpMfaNow()
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $this->assertFormContains('name="setUpMfa"', $page);
     }
 
@@ -142,7 +142,7 @@ class MfaContext extends FeatureContext
      */
     public function iShouldSeeAPromptForABackupCode()
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $pageHtml = $page->getHtml();
         Assert::assertContains('Printable code', $pageHtml);
         Assert::assertContains('Enter code', $pageHtml);
@@ -163,7 +163,7 @@ class MfaContext extends FeatureContext
      */
     public function iShouldSeeAPromptForATotpCode()
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $pageHtml = $page->getHtml();
         Assert::assertContains('Enter 6-digit code', $pageHtml);
     }
@@ -183,16 +183,16 @@ class MfaContext extends FeatureContext
      */
     public function iShouldSeeAPromptForAWebAuthn()
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         Assert::assertContains('Security key', $page->getHtml());
     }
 
     protected function submitMfaValue($mfaValue)
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $page->fillField('mfaSubmission', $mfaValue);
         $this->submitMfaForm($page);
-        return $page->getHtml();
+        return $page->getHtml(); // TODO: see if this is safe
     }
 
     /**
@@ -202,7 +202,8 @@ class MfaContext extends FeatureContext
     {
         if (!$this->pageContainsElementWithText('h1', 'Printable code')) {
             // find image of the backup code option presented in other_mfas.twig
-            $printableCodeOption = $this->session->getPage()->find('css', 'img[src=mfa-backupcode\002Esvg]');
+            $page = $this->getSession()->getPage();
+            $printableCodeOption = $page->find('css', 'img[src=mfa-backupcode\002Esvg]');
             $printableCodeOption->click();
         }
         $this->submitMfaValue(FakeIdBrokerClient::CORRECT_VALUE);
@@ -210,7 +211,7 @@ class MfaContext extends FeatureContext
 
     protected function pageContainsElementWithText($cssSelector, $text)
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $elements = $page->findAll('css', $cssSelector);
         foreach ($elements as $element) {
             if (strpos($element->getText(), $text) !== false) {
@@ -233,7 +234,7 @@ class MfaContext extends FeatureContext
      */
     public function iShouldSeeAMessageThatIHaveToWaitBeforeTryingAgain()
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $pageHtml = $page->getHtml();
         Assert::assertContains(' wait ', $pageHtml);
         Assert::assertContains('try again', $pageHtml);
@@ -244,7 +245,7 @@ class MfaContext extends FeatureContext
      */
     public function iShouldSeeAMessageThatItWasIncorrect()
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $pageHtml = $page->getHtml();
         Assert::assertContains('Incorrect 2-step verification code', $pageHtml);
     }
@@ -264,7 +265,7 @@ class MfaContext extends FeatureContext
      */
     public function thereShouldBeAWayToContinueToMyIntendedDestination()
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $this->assertFormContains('name="continue"', $page);
     }
 
@@ -291,7 +292,7 @@ class MfaContext extends FeatureContext
     {
         $mfaSetupUrl = Env::get('PROFILE_URL_FOR_TESTS');
         Assert::assertNotEmpty($mfaSetupUrl, 'No PROFILE_URL_FOR_TESTS provided');
-        $currentUrl = $this->session->getCurrentUrl();
+        $currentUrl = $this->getSession()->getCurrentUrl();
         Assert::assertStringStartsWith(
             $mfaSetupUrl,
             $currentUrl,
@@ -304,7 +305,7 @@ class MfaContext extends FeatureContext
      */
     public function thereShouldNotBeAWayToContinueToMyIntendedDestination()
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $continueButton = $this->getContinueButton($page);
         Assert::assertNull($continueButton, 'Should not have found a continue button');
     }
@@ -314,10 +315,10 @@ class MfaContext extends FeatureContext
      */
     public function iShouldNotBeAbleToGetToMyIntendedDestination()
     {
-        $this->session->visit(self::SP1_LOGIN_PAGE);
+        $this->getSession()->visit(self::SP1_LOGIN_PAGE);
         Assert::assertStringStartsNotWith(
             self::SP1_LOGIN_PAGE,
-            $this->session->getCurrentUrl(),
+            $this->getSession()->getCurrentUrl(),
             'Failed to prevent me from getting to SPs other than the MFA setup URL'
         );
     }
@@ -337,7 +338,7 @@ class MfaContext extends FeatureContext
      */
     public function iShouldSeeAMessageThatIAmRunningLowOnBackupCodes()
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         Assert::assertContains(
             'Almost out of printable codes',
             $page->getHtml()
@@ -349,7 +350,7 @@ class MfaContext extends FeatureContext
      */
     public function thereShouldBeAWayToGetMoreBackupCodesNow()
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $this->assertFormContains('name="getMore"', $page);
     }
 
@@ -368,7 +369,7 @@ class MfaContext extends FeatureContext
      */
     public function iShouldSeeAMessageThatIHaveUsedUpMyBackupCodes()
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         Assert::assertContains(
             'Last printable code used',
             $page->getHtml()
@@ -398,7 +399,7 @@ class MfaContext extends FeatureContext
      */
     public function iShouldBeToldIOnlyHaveBackupCodesLeft($numRemaining)
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         Assert::assertContains(
             'You only have ' . $numRemaining . ' more left',
             $page->getHtml()
@@ -410,7 +411,7 @@ class MfaContext extends FeatureContext
      */
     public function iShouldBeGivenMoreBackupCodes()
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         Assert::assertContains(
             'New printable codes',
             $page->getContent()
@@ -558,7 +559,7 @@ class MfaContext extends FeatureContext
      */
     public function iShouldSeeALinkToSendACodeToTheUsersManager()
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         Assert::assertContains(
             '/module.php/mfa/send-manager-mfa.php',
             $page->getContent()
@@ -580,7 +581,7 @@ class MfaContext extends FeatureContext
      */
     public function iShouldNotSeeALinkToSendACodeToTheUsersManager()
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         Assert::assertNotContains(
             '/module.php/mfa/send-manager-mfa.php',
             $page->getContent()
@@ -592,7 +593,7 @@ class MfaContext extends FeatureContext
      */
     public function iClickTheRequestAssistanceLink()
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $helpOption = $page->findById('more-options-manager');
         Assert::assertNotNull(
             $helpOption,
@@ -614,7 +615,7 @@ class MfaContext extends FeatureContext
      */
     public function iShouldSeeAPromptForAManagerRescueCode()
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $pageHtml = $page->getHtml();
         Assert::assertContains('Ask Your Recovery Contact for Help', $pageHtml);
         Assert::assertContains('Enter code', $pageHtml);
@@ -652,7 +653,7 @@ class MfaContext extends FeatureContext
      */
     public function thereShouldBeAWayToRequestAManagerCode()
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         Assert::assertContains('Ask Your Recovery Contact', $page->getHtml());
         $this->assertFormContains('name="send"', $page);
     }

--- a/features/bootstrap/MfaContext.php
+++ b/features/bootstrap/MfaContext.php
@@ -75,6 +75,7 @@ class MfaContext extends FeatureContext
         ));
         Assert::assertNotNull($button, 'Failed to find button named ' . $buttonName);
         $button->click();
+        $this->getSession()->wait(5000, 'document.readyState === "complete"');
     }
 
     /**
@@ -87,6 +88,7 @@ class MfaContext extends FeatureContext
     {
         $submitMfaButton = $this->getSubmitMfaButton($page);
         $submitMfaButton->click();
+        $this->getSession()->wait(5000, 'document.readyState === "complete"');
     }
 
     /**
@@ -205,6 +207,7 @@ class MfaContext extends FeatureContext
             $page = $this->getSession()->getPage();
             $printableCodeOption = $page->find('css', 'img[src=mfa-backupcode\002Esvg]');
             $printableCodeOption->click();
+            $this->getSession()->wait(5000, 'document.readyState === "complete"');
         }
         $this->submitMfaValue(FakeIdBrokerClient::CORRECT_VALUE);
     }
@@ -600,6 +603,7 @@ class MfaContext extends FeatureContext
             'Could not find the "I need help" option'
         );
         $helpOption->click();
+        $this->getSession()->wait(5000, 'document.readyState === "complete"');
     }
 
     /**

--- a/features/bootstrap/MfaContext.php
+++ b/features/bootstrap/MfaContext.php
@@ -291,7 +291,15 @@ class MfaContext extends FeatureContext
     {
         $mfaSetupUrl = Env::get('PROFILE_URL_FOR_TESTS');
         Assert::assertNotEmpty($mfaSetupUrl, 'No PROFILE_URL_FOR_TESTS provided');
-        $currentUrl = $this->getSession()->getCurrentUrl();
+        $expectedUrl = json_encode($mfaSetupUrl, JSON_UNESCAPED_SLASHES);
+        $session = $this->getSession();
+        $session->wait(1000, <<<JS
+  document.readyState === "complete"
+  && window.location
+  && window.location.href === $expectedUrl
+JS);
+
+        $currentUrl = $session->getCurrentUrl();
         Assert::assertStringStartsWith(
             $mfaSetupUrl,
             $currentUrl,

--- a/features/bootstrap/MfaContext.php
+++ b/features/bootstrap/MfaContext.php
@@ -192,7 +192,6 @@ class MfaContext extends FeatureContext
         $page = $this->getSession()->getPage();
         $page->fillField('mfaSubmission', $mfaValue);
         $this->submitMfaForm($page);
-        return $page->getHtml(); // TODO: see if this is safe
     }
 
     /**

--- a/features/bootstrap/MfaContext.php
+++ b/features/bootstrap/MfaContext.php
@@ -75,7 +75,6 @@ class MfaContext extends FeatureContext
         ));
         Assert::assertNotNull($button, 'Failed to find button named ' . $buttonName);
         $button->click();
-        $this->getSession()->wait(5000, 'document.readyState === "complete"');
     }
 
     /**
@@ -88,7 +87,6 @@ class MfaContext extends FeatureContext
     {
         $submitMfaButton = $this->getSubmitMfaButton($page);
         $submitMfaButton->click();
-        $this->getSession()->wait(5000, 'document.readyState === "complete"');
     }
 
     /**
@@ -207,7 +205,6 @@ class MfaContext extends FeatureContext
             $page = $this->getSession()->getPage();
             $printableCodeOption = $page->find('css', 'img[src=mfa-backupcode\002Esvg]');
             $printableCodeOption->click();
-            $this->getSession()->wait(5000, 'document.readyState === "complete"');
         }
         $this->submitMfaValue(FakeIdBrokerClient::CORRECT_VALUE);
     }
@@ -603,7 +600,6 @@ class MfaContext extends FeatureContext
             'Could not find the "I need help" option'
         );
         $helpOption->click();
-        $this->getSession()->wait(5000, 'document.readyState === "complete"');
     }
 
     /**

--- a/features/bootstrap/MfaContext.php
+++ b/features/bootstrap/MfaContext.php
@@ -75,7 +75,6 @@ class MfaContext extends FeatureContext
         ));
         Assert::assertNotNull($button, 'Failed to find button named ' . $buttonName);
         $button->click();
-        $this->submitSecondarySspFormIfPresent($page);
     }
 
     /**
@@ -88,7 +87,6 @@ class MfaContext extends FeatureContext
     {
         $submitMfaButton = $this->getSubmitMfaButton($page);
         $submitMfaButton->click();
-        $this->submitSecondarySspFormIfPresent($page);
     }
 
     /**

--- a/features/bootstrap/MfaRecoveryContext.php
+++ b/features/bootstrap/MfaRecoveryContext.php
@@ -1,9 +1,9 @@
 <?php
 
-use Behat\Step\When;
 use Behat\Mink\Element\DocumentElement;
 use Behat\Step\Given;
 use Behat\Step\Then;
+use Behat\Step\When;
 use PHPUnit\Framework\Assert;
 use Sil\PhpEnv\Env;
 use SimpleSAML\Module\mfa\Auth\Process\Mfa;
@@ -22,7 +22,7 @@ class MfaRecoveryContext extends MfaContext
     #[Then('I should see a link to send a code to a recovery contact')]
     public function iShouldSeeALinkToSendACodeToARecoveryContact(): void
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         Assert::assertContains(
             '/module.php/mfa/send-recovery-mfa.php',
             $page->getContent()
@@ -32,7 +32,7 @@ class MfaRecoveryContext extends MfaContext
     #[Then('I should see a way to send an MFA recovery code to my manager')]
     public function iShouldSeeAWayToSendAnMfaRecoveryCodeToMyManager(): void
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         Assert::assertNotNull(
             $page->findById('option-manager'),
             'Did not find a way to select my manager'
@@ -52,7 +52,7 @@ class MfaRecoveryContext extends MfaContext
     #[Then('I should see a way to send an MFA recovery code to another recovery contact')]
     public function iShouldSeeAWayToSendAnMfaRecoveryCodeToAnotherRecoveryContact(): void
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $foundNonManagerOption = false;
         $contactOptionElements = $page->findAll('css', 'input[name=mfaRecoveryContactID]');
         foreach ($contactOptionElements as $element) {
@@ -79,7 +79,7 @@ class MfaRecoveryContext extends MfaContext
 
     protected function selectARecoveryContactOption(): void
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $contactOptionElements = $page->findAll('css', 'input[name=mfaRecoveryContactID]');
         foreach ($contactOptionElements as $element) {
             $elementID = $element->getAttribute('id');
@@ -94,7 +94,7 @@ class MfaRecoveryContext extends MfaContext
     #[Then('I should not see an error message')]
     public function iShouldNotSeeAnErrorMessage(): void
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         Assert::assertNotContains(
             'error',
             $page->getContent()
@@ -104,7 +104,7 @@ class MfaRecoveryContext extends MfaContext
     #[Then('I should see confirmation that the code was sent')]
     public function iShouldSeeConfirmationThatTheCodeWasSent(): void
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         Assert::assertContains(
             'A temporary code was sent to your recovery contact',
             $page->getContent()
@@ -147,7 +147,7 @@ class MfaRecoveryContext extends MfaContext
     #[Then('I should see :optionText as one of the recovery contact options')]
     public function iShouldSeeAsOneOfTheRecoveryContactOptions($optionText): void
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         Assert::assertContains(
             'your supervisor',
             $page->getContent()
@@ -164,7 +164,7 @@ class MfaRecoveryContext extends MfaContext
         $recoveryContacts = $this->getRecoveryContactsFromMockApiFor($emailAddress);
         Assert::assertNotEmpty($recoveryContacts, 'API returned no recovery contacts');
 
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         foreach (array_keys($recoveryContacts) as $recoveryContactName) {
             Assert::assertNotContains(
                 $recoveryContactName,
@@ -182,7 +182,7 @@ class MfaRecoveryContext extends MfaContext
     #[When('I send the code to the manager')]
     public function iSendTheCodeToTheManager(): void
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $managerOption = $page->findById('option-manager');
         $managerOption->click();
         $page->pressButton('send');
@@ -205,7 +205,7 @@ class MfaRecoveryContext extends MfaContext
     #[Then('I should see a way to send an MFA recovery code to the fallback recovery contact')]
     public function iShouldSeeAWayToSendAnMfaRecoveryCodeToTheFallbackRecoveryContact(): void
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $fallbackName = Env::requireEnv('MFA_RECOVERY_CONTACTS_FALLBACK_NAME');
         $foundFallbackOption = false;
 
@@ -235,7 +235,7 @@ class MfaRecoveryContext extends MfaContext
     #[Then('I should see a way to send an MFA recovery code to this account\'s recovery contact')]
     public function iShouldSeeAWayToSendAnMfaRecoveryCodeToThisAccountsRecoveryContact(): void
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $recoveryContactFullName = 'Anne Admin'; // Must match value in `api-mock/mfa-recovery-contacts.json`
         $recoveryContactAbbreviatedName = Mfa::abbreviateName($recoveryContactFullName);
         $foundThatRecoveryContact = false;

--- a/features/bootstrap/MfaRecoveryContext.php
+++ b/features/bootstrap/MfaRecoveryContext.php
@@ -85,7 +85,6 @@ class MfaRecoveryContext extends MfaContext
             $elementID = $element->getAttribute('id');
             if ($elementID !== 'option-manager') {
                 $element->click();
-                $this->getSession()->wait(5000, 'document.readyState === "complete"');
                 return;
             }
         }
@@ -186,9 +185,7 @@ class MfaRecoveryContext extends MfaContext
         $page = $this->getSession()->getPage();
         $managerOption = $page->findById('option-manager');
         $managerOption->click();
-        $this->getSession()->wait(5000, 'document.readyState === "complete"');
         $page->pressButton('send');
-        $this->getSession()->wait(5000, 'document.readyState === "complete"');
     }
 
     #[Given('I provide credentials that have backup codes and a manager')]

--- a/features/bootstrap/MfaRecoveryContext.php
+++ b/features/bootstrap/MfaRecoveryContext.php
@@ -85,6 +85,7 @@ class MfaRecoveryContext extends MfaContext
             $elementID = $element->getAttribute('id');
             if ($elementID !== 'option-manager') {
                 $element->click();
+                $this->getSession()->wait(5000, 'document.readyState === "complete"');
                 return;
             }
         }
@@ -185,7 +186,9 @@ class MfaRecoveryContext extends MfaContext
         $page = $this->getSession()->getPage();
         $managerOption = $page->findById('option-manager');
         $managerOption->click();
+        $this->getSession()->wait(5000, 'document.readyState === "complete"');
         $page->pressButton('send');
+        $this->getSession()->wait(5000, 'document.readyState === "complete"');
     }
 
     #[Given('I provide credentials that have backup codes and a manager')]

--- a/features/bootstrap/ProfileReviewContext.php
+++ b/features/bootstrap/ProfileReviewContext.php
@@ -48,7 +48,6 @@ class ProfileReviewContext extends FeatureContext
         ));
         Assert::assertNotNull($button, 'Failed to find button named ' . $buttonName);
         $button->click();
-        $this->getSession()->wait(5000, 'document.readyState === "complete"');
     }
 
     /**

--- a/features/bootstrap/ProfileReviewContext.php
+++ b/features/bootstrap/ProfileReviewContext.php
@@ -1,8 +1,6 @@
 <?php
 
 use Behat\Mink\Element\DocumentElement;
-use Behat\Mink\Element\NodeElement;
-use Behat\Mink\Exception\ElementNotFoundException;
 use PHPUnit\Framework\Assert;
 use Sil\PhpEnv\Env;
 
@@ -50,7 +48,6 @@ class ProfileReviewContext extends FeatureContext
         ));
         Assert::assertNotNull($button, 'Failed to find button named ' . $buttonName);
         $button->click();
-        $this->submitSecondarySspFormIfPresent($page);
     }
 
     /**

--- a/features/bootstrap/ProfileReviewContext.php
+++ b/features/bootstrap/ProfileReviewContext.php
@@ -41,7 +41,7 @@ class ProfileReviewContext extends FeatureContext
      */
     protected function submitFormByClickingButtonNamed($buttonName)
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $button = $page->find('css', sprintf(
             '[name=%s]',
             $buttonName
@@ -91,7 +91,7 @@ class ProfileReviewContext extends FeatureContext
 
     protected function pageContainsElementWithText($cssSelector, $text)
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $elements = $page->findAll('css', $cssSelector);
         foreach ($elements as $element) {
             if (strpos($element->getText(), $text) !== false) {
@@ -106,7 +106,7 @@ class ProfileReviewContext extends FeatureContext
      */
     public function thereShouldBeAWayToContinueToMyIntendedDestination()
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $this->assertFormContains('name="continue"', $page);
     }
 
@@ -141,7 +141,7 @@ class ProfileReviewContext extends FeatureContext
     {
         $profileUrl = Env::get('PROFILE_URL_FOR_TESTS');
         Assert::assertNotEmpty($profileUrl, 'No PROFILE_URL_FOR_TESTS provided');
-        $currentUrl = $this->session->getCurrentUrl();
+        $currentUrl = $this->getSession()->getCurrentUrl();
         Assert::assertStringStartsWith(
             $profileUrl,
             $currentUrl,
@@ -157,13 +157,13 @@ class ProfileReviewContext extends FeatureContext
         $profileUrl = Env::get('PROFILE_URL_FOR_TESTS');
         Assert::assertNotEmpty($profileUrl, 'No PROFILE_URL_FOR_TESTS provided');
 
-        $windowNames = $this->session->getWindowNames();
+        $windowNames = $this->getSession()->getWindowNames();
         Assert::assertGreaterThanOrEqual(2, sizeof($windowNames),
             'Expected to see at least 2 windows opened');
 
         foreach ($windowNames as $windowName) {
-            $this->session->switchToWindow($windowName);
-            $currentUrl = $this->session->getCurrentUrl();
+            $this->getSession()->switchToWindow($windowName);
+            $currentUrl = $this->getSession()->getCurrentUrl();
             if ($currentUrl == $profileUrl) {
                 return;
             }
@@ -177,7 +177,7 @@ class ProfileReviewContext extends FeatureContext
      */
     public function iShouldSeeTheMessage($message)
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         Assert::assertContains($message, $page->getHtml());
     }
 
@@ -186,7 +186,7 @@ class ProfileReviewContext extends FeatureContext
      */
     public function thereShouldBeAWayToGoUpdateMyProfileNow()
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $this->assertFormContains('name="update"', $page);
     }
 
@@ -195,7 +195,7 @@ class ProfileReviewContext extends FeatureContext
      */
     public function thereShouldBeAWayToGoReviewMyProfileNow()
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         Assert::assertContains('Some of these need updating', $page->getHtml());
     }
 
@@ -214,7 +214,7 @@ class ProfileReviewContext extends FeatureContext
      */
     public function iShouldNotSeeAnyManagerMfaInformation()
     {
-        $page = $this->session->getPage();
+        $page = $this->getSession()->getPage();
         $isManagerMfaPresent = $page->hasContent('manager');
         Assert::assertFalse($isManagerMfaPresent, 'found manager mfa data');
     }

--- a/features/bootstrap/ProfileReviewContext.php
+++ b/features/bootstrap/ProfileReviewContext.php
@@ -139,9 +139,18 @@ class ProfileReviewContext extends FeatureContext
      */
     public function iShouldEndUpAtTheUpdateProfileUrl()
     {
+
         $profileUrl = Env::get('PROFILE_URL_FOR_TESTS');
         Assert::assertNotEmpty($profileUrl, 'No PROFILE_URL_FOR_TESTS provided');
-        $currentUrl = $this->getSession()->getCurrentUrl();
+        $expectedUrl = json_encode($profileUrl, JSON_UNESCAPED_SLASHES);
+        $session = $this->getSession();
+        $session->wait(1000, <<<JS
+  document.readyState === "complete"
+  && window.location
+  && window.location.href.startsWith($expectedUrl)
+JS);
+
+        $currentUrl = $session->getCurrentUrl();
         Assert::assertStringStartsWith(
             $profileUrl,
             $currentUrl,
@@ -154,22 +163,45 @@ class ProfileReviewContext extends FeatureContext
      */
     public function iShouldEndUpAtTheUpdateProfileUrlOnANewTab()
     {
+        $session = $this->getSession();
+
         $profileUrl = Env::get('PROFILE_URL_FOR_TESTS');
         Assert::assertNotEmpty($profileUrl, 'No PROFILE_URL_FOR_TESTS provided');
 
-        $windowNames = $this->getSession()->getWindowNames();
-        Assert::assertGreaterThanOrEqual(2, sizeof($windowNames),
-            'Expected to see at least 2 windows opened');
-
-        foreach ($windowNames as $windowName) {
-            $this->getSession()->switchToWindow($windowName);
-            $currentUrl = $this->getSession()->getCurrentUrl();
-            if ($currentUrl == $profileUrl) {
-                return;
+        // Wait until a new tab/window appears
+        $deadline = microtime(true) + 2; // seconds
+        do {
+            $windowNames = $session->getWindowNames();
+            if (count($windowNames) >= 2) {
+                break;
             }
-        }
+            $session->wait(100);
+        } while (microtime(true) < $deadline);
 
-        Assert::fail('Did NOT end up at the update profile URL');
+        Assert::assertGreaterThanOrEqual(
+            2,
+            count($windowNames),
+            'Expected to see at least 2 windows opened'
+        );
+
+        // Wait until one of the windows reaches the expected URL
+        $deadline = microtime(true) + 2; // seconds
+        do {
+            foreach ($session->getWindowNames() as $windowName) {
+                $session->switchToWindow($windowName);
+
+                $session->wait(100, 'document.readyState === "complete"');
+
+                if ($session->getCurrentUrl() === $profileUrl) {
+                    return;
+                }
+            }
+
+            $session->wait(100);
+        } while (microtime(true) < $deadline);
+
+        Assert::fail("Did not find a window on the profile URL {$profileUrl}. Last seen windows: " .
+            implode(', ', $session->getWindowNames()));
     }
 
     /**

--- a/features/bootstrap/ProfileReviewContext.php
+++ b/features/bootstrap/ProfileReviewContext.php
@@ -48,6 +48,7 @@ class ProfileReviewContext extends FeatureContext
         ));
         Assert::assertNotNull($button, 'Failed to find button named ' . $buttonName);
         $button->click();
+        $this->getSession()->wait(5000, 'document.readyState === "complete"');
     }
 
     /**

--- a/features/bootstrap/ProfileReviewContext.php
+++ b/features/bootstrap/ProfileReviewContext.php
@@ -142,15 +142,9 @@ class ProfileReviewContext extends FeatureContext
 
         $profileUrl = Env::get('PROFILE_URL_FOR_TESTS');
         Assert::assertNotEmpty($profileUrl, 'No PROFILE_URL_FOR_TESTS provided');
-        $expectedUrl = json_encode($profileUrl, JSON_UNESCAPED_SLASHES);
-        $session = $this->getSession();
-        $session->wait(1000, <<<JS
-  document.readyState === "complete"
-  && window.location
-  && window.location.href.startsWith($expectedUrl)
-JS);
+        $this->waitForPage($profileUrl);
 
-        $currentUrl = $session->getCurrentUrl();
+        $currentUrl = $this->getSession()->getCurrentUrl();
         Assert::assertStringStartsWith(
             $profileUrl,
             $currentUrl,

--- a/features/bootstrap/SilDiscoContext.php
+++ b/features/bootstrap/SilDiscoContext.php
@@ -102,6 +102,13 @@ JS);
      */
     public function iShouldBePromptedForAUsernameAndPassword()
     {
+        $expectedPath = json_encode('module.php/core/loginuserpass', JSON_UNESCAPED_SLASHES);
+        Assert::assertTrue($this->getSession()->wait(1000, <<<JS
+  document.readyState === "complete"
+  && window.location
+  && window.location.href.includes($expectedPath)
+JS), 'Did not reach the login page');
+
         $this->assertPageBodyContainsText('Enter your username and password');
     }
 

--- a/features/bootstrap/SilDiscoContext.php
+++ b/features/bootstrap/SilDiscoContext.php
@@ -38,13 +38,7 @@ class SilDiscoContext extends FeatureContext
      */
     public function iShouldEndUpAtMyIntendedDestinationOnSp($sp)
     {
-        $expectedPath = json_encode('module.php/core/welcome', JSON_UNESCAPED_SLASHES);
-        $session = $this->getSession();
-        $session->wait(1000, <<<JS
-  document.readyState === "complete"
-  && window.location
-  && window.location.href.endsWith($expectedPath)
-JS);
+        $this->waitForPage('module.php/core/welcome');
 
         $currentUrl = $this->getSession()->getCurrentUrl();
         Assert::assertStringStartsWith(
@@ -71,23 +65,13 @@ JS);
         $this->iGoToTheSpLoginPage($sp);
         $this->iClickOnTheTile('IDP 1');
 
-        $expectedPath = json_encode('module.php/core/loginuserpass', JSON_UNESCAPED_SLASHES);
-        Assert::assertTrue($this->getSession()->wait(1000, <<<JS
-  document.readyState === "complete"
-  && window.location
-  && window.location.href.includes($expectedPath)
-JS), 'Did not reach the login page');
+        $this->waitForPage('module.php/core/loginuserpass');
 
         $this->username = 'sildisco_idp1';
         $this->password = 'sildisco_password';
         $this->iLogIn();
 
-        $expectedPath = json_encode('module.php/core/welcome', JSON_UNESCAPED_SLASHES);
-        Assert::assertTrue($this->getSession()->wait(1000, <<<JS
-  document.readyState === "complete"
-  && window.location
-  && window.location.href.includes($expectedPath)
-JS), 'Did not reach the welcome page');
+        $this->waitForPage('module.php/core/welcome');
     }
 
     /**
@@ -111,12 +95,7 @@ JS), 'Did not reach the welcome page');
     {
         $this->visit(self::SP1_LOGOUT_PAGE);
 
-        $expectedPath = json_encode('module.php/core/welcome', JSON_UNESCAPED_SLASHES);
-        Assert::assertTrue($this->getSession()->wait(1000, <<<JS
-  document.readyState === "complete"
-  && window.location
-  && window.location.href.includes($expectedPath)
-JS), 'Did not reach the welcome page');
+        $this->waitForPage('module.php/core/welcome');
     }
 
     /**
@@ -124,12 +103,7 @@ JS), 'Did not reach the welcome page');
      */
     public function iShouldBePromptedForAUsernameAndPassword()
     {
-        $expectedPath = json_encode('module.php/core/loginuserpass', JSON_UNESCAPED_SLASHES);
-        Assert::assertTrue($this->getSession()->wait(1000, <<<JS
-  document.readyState === "complete"
-  && window.location
-  && window.location.href.includes($expectedPath)
-JS), 'Did not reach the login page');
+        $this->waitForPage('module.php/core/loginuserpass');
 
         $this->assertPageBodyContainsText('Enter your username and password');
     }

--- a/features/bootstrap/SilDiscoContext.php
+++ b/features/bootstrap/SilDiscoContext.php
@@ -38,6 +38,14 @@ class SilDiscoContext extends FeatureContext
      */
     public function iShouldEndUpAtMyIntendedDestinationOnSp($sp)
     {
+        $expectedPath = json_encode('module.php/core/welcome', JSON_UNESCAPED_SLASHES);
+        $session = $this->getSession();
+        $session->wait(1000, <<<JS
+  document.readyState === "complete"
+  && window.location
+  && window.location.href.endsWith($expectedPath)
+JS);
+
         $currentUrl = $this->getSession()->getCurrentUrl();
         Assert::assertStringStartsWith(
             'http://ssp-' . strtolower($sp),

--- a/features/bootstrap/SilDiscoContext.php
+++ b/features/bootstrap/SilDiscoContext.php
@@ -38,7 +38,7 @@ class SilDiscoContext extends FeatureContext
      */
     public function iShouldEndUpAtMyIntendedDestinationOnSp($sp)
     {
-        $currentUrl = $this->session->getCurrentUrl();
+        $currentUrl = $this->getSession()->getCurrentUrl();
         Assert::assertStringStartsWith(
             'http://ssp-' . strtolower($sp),
             $currentUrl,
@@ -102,10 +102,10 @@ class SilDiscoContext extends FeatureContext
      */
     public function iShouldSeeTheMetadataInXmlFormat()
     {
-        $contentType = $this->session->getResponseHeader('Content-Type');
+        $contentType = $this->getSession()->getResponseHeader('Content-Type');
         Assert::assertEquals('application/xml', $contentType);
 
-        Assert::assertEquals(200, $this->session->getStatusCode());
+        Assert::assertEquals(200, $this->getSession()->getStatusCode());
 
         $xml = file_get_contents($this->getSession()->getCurrentUrl());
         Assert::assertStringContainsString(

--- a/features/bootstrap/SilDiscoContext.php
+++ b/features/bootstrap/SilDiscoContext.php
@@ -70,9 +70,24 @@ JS);
     {
         $this->iGoToTheSpLoginPage($sp);
         $this->iClickOnTheTile('IDP 1');
+
+        $expectedPath = json_encode('module.php/core/loginuserpass', JSON_UNESCAPED_SLASHES);
+        Assert::assertTrue($this->getSession()->wait(1000, <<<JS
+  document.readyState === "complete"
+  && window.location
+  && window.location.href.includes($expectedPath)
+JS), 'Did not reach the login page');
+
         $this->username = 'sildisco_idp1';
         $this->password = 'sildisco_password';
         $this->iLogIn();
+
+        $expectedPath = json_encode('module.php/core/welcome', JSON_UNESCAPED_SLASHES);
+        Assert::assertTrue($this->getSession()->wait(1000, <<<JS
+  document.readyState === "complete"
+  && window.location
+  && window.location.href.includes($expectedPath)
+JS), 'Did not reach the welcome page');
     }
 
     /**
@@ -95,6 +110,13 @@ JS);
     public function iLogOutOfIdp1()
     {
         $this->visit(self::SP1_LOGOUT_PAGE);
+
+        $expectedPath = json_encode('module.php/core/welcome', JSON_UNESCAPED_SLASHES);
+        Assert::assertTrue($this->getSession()->wait(1000, <<<JS
+  document.readyState === "complete"
+  && window.location
+  && window.location.href.includes($expectedPath)
+JS), 'Did not reach the welcome page');
     }
 
     /**

--- a/features/sildisco.feature
+++ b/features/sildisco.feature
@@ -34,9 +34,9 @@ Feature: SIL IdP discovery (sildisco) module
     And I log in using my "IDP 1" credentials
     Then I should end up at my intended destination on SP3
 
-  Scenario: IdP Logout
-    Given I have authenticated with IDP1 for SP1
-    When I log out of IDP1
-     And I go to the SP1 login page
-     And I click on the "IDP 1" tile
-    Then I should be prompted for a username and password
+#  Scenario: IdP Logout
+#    Given I have authenticated with IDP1 for SP1
+#    When I log out of IDP1
+#     And I go to the SP1 login page
+#     And I click on the "IDP 1" tile
+#    Then I should be prompted for a username and password

--- a/features/sildisco.feature
+++ b/features/sildisco.feature
@@ -34,9 +34,9 @@ Feature: SIL IdP discovery (sildisco) module
     And I log in using my "IDP 1" credentials
     Then I should end up at my intended destination on SP3
 
-#  Scenario: IdP Logout
-#    Given I have authenticated with IDP1 for SP1
-#    When I log out of IDP1
-#     And I go to the SP1 login page
-#     And I click on the "IDP 1" tile
-#    Then I should be prompted for a username and password
+  Scenario: IdP Logout
+    Given I have authenticated with IDP1 for SP1
+    When I log out of IDP1
+    And I go to the SP1 login page
+    And I click on the "IDP 1" tile
+    Then I should be prompted for a username and password


### PR DESCRIPTION
[IDP-1925](https://support.gtis.sil.org/issue/IDP-1925) ssp-base test failure: Don't prompt for MFA

---

### Fixed
- Fixed flaky tests.
  - Don't retain the session in the context. Get a fresh copy as needed.
  - Use `wait()` to ensure the browser has finished redirecting to the destination.
  - Use a `wait()` on body content match instead of an instantaneous snapshot of the page content, just in case it is still changing.
  - Removed `submitSecondarySspFormIfPresent` as outdated for SimpleSAMLphp 2.x.
- Remove unused `use` lines.