### PR TITLE
Disable admin module

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -134,6 +134,8 @@ services:
       - ./development/hub/cert:/data/vendor/simplesamlphp/simplesamlphp/cert
 
       # Utilize custom configs
+      - ./dockerbuild/config/config.php:/data/vendor/simplesamlphp/simplesamlphp/config/config.php
+      - ./development/hub/config/extra-config.php:/data/extra-config.php
       - ./development/hub/config/authsources.php:/data/vendor/simplesamlphp/simplesamlphp/config/authsources.php
       - ./dockerbuild/config/config.php:/data/vendor/simplesamlphp/simplesamlphp/config/config.php
       - ./development/announcement.php:/data/vendor/simplesamlphp/simplesamlphp/announcement/announcement.php
@@ -180,9 +182,10 @@ services:
       - ./development/idp-local/cert:/data/vendor/simplesamlphp/simplesamlphp/cert
 
       # Utilize custom configs
+      - ./dockerbuild/config/config.php:/data/vendor/simplesamlphp/simplesamlphp/config/config.php
+      - ./development/idp-local/config/extra-config.php:/data/extra-config.php
       - ./development/idp-local/config/authsources.php:/data/vendor/simplesamlphp/simplesamlphp/config/authsources.php
       - ./development/announcement.php:/data/vendor/simplesamlphp/simplesamlphp/announcement/announcement.php
-      - ./development/enable-exampleauth.sh:/data/enable-exampleauth.sh
       - ./development/logo_idp1.png:/data/vendor/simplesamlphp/simplesamlphp/public/logo.png
 
       # Utilize custom metadata
@@ -205,7 +208,7 @@ services:
       - ./modules/sildisco:/data/vendor/simplesamlphp/simplesamlphp/modules/sildisco
       - ./modules/material:/data/vendor/simplesamlphp/simplesamlphp/modules/material
     command: >
-      bash -c "/data/enable-exampleauth.sh && /data/run-idp.sh"
+      bash -c "/data/run-idp.sh"
     ports:
       - "8085:80"
     environment:
@@ -254,8 +257,9 @@ services:
       - ./development/idp2-local/cert:/data/vendor/simplesamlphp/simplesamlphp/cert
 
       # Utilize custom configs
+      - ./dockerbuild/config/config.php:/data/vendor/simplesamlphp/simplesamlphp/config/config.php
+      - ./development/idp2-local/config/extra-config.php:/data/extra-config.php
       - ./development/idp2-local/config/authsources.php:/data/vendor/simplesamlphp/simplesamlphp/config/authsources.php
-      - ./development/enable-exampleauth.sh:/data/enable-exampleauth.sh
       - ./development/logo_idp2.png:/data/vendor/simplesamlphp/simplesamlphp/public/logo.png
 
       # Utilize custom metadata
@@ -271,7 +275,6 @@ services:
       - ./modules/silauth:/data/vendor/simplesamlphp/simplesamlphp/modules/silauth
       - ./modules/sildisco:/data/vendor/simplesamlphp/simplesamlphp/modules/sildisco
       - ./modules/material:/data/vendor/simplesamlphp/simplesamlphp/modules/material
-    command: bash -c "/data/enable-exampleauth.sh && /data/run.sh"
     ports:
       - "8086:80"
     environment:
@@ -307,6 +310,8 @@ services:
       - ./development/idp3-local/cert:/data/vendor/simplesamlphp/simplesamlphp/cert
 
       # Utilize custom configs
+      - ./dockerbuild/config/config.php:/data/vendor/simplesamlphp/simplesamlphp/config/config.php
+      - ./development/idp-local/config/extra-config.php:/data/extra-config.php
       - ./development/idp3-local/config/authsources.php:/data/vendor/simplesamlphp/simplesamlphp/config/authsources.php
       - ./development/logo_idp3.png:/data/vendor/simplesamlphp/simplesamlphp/public/logo.png
 
@@ -346,8 +351,9 @@ services:
       - ./development/idp4-local/cert:/data/vendor/simplesamlphp/simplesamlphp/cert
 
       # Utilize custom configs
+      - ./dockerbuild/config/config.php:/data/vendor/simplesamlphp/simplesamlphp/config/config.php
+      - ./development/idp-local/config/extra-config.php:/data/extra-config.php
       - ./development/idp4-local/config/authsources.php:/data/vendor/simplesamlphp/simplesamlphp/config/authsources.php
-      - ./development/enable-exampleauth.sh:/data/enable-exampleauth.sh
 
       # Utilize custom metadata
       - ./development/idp4-local/metadata:/data/vendor/simplesamlphp/simplesamlphp/metadata
@@ -365,7 +371,6 @@ services:
       - ./modules/silauth:/data/vendor/simplesamlphp/simplesamlphp/modules/silauth
       - ./modules/sildisco:/data/vendor/simplesamlphp/simplesamlphp/modules/sildisco
       - ./modules/material:/data/vendor/simplesamlphp/simplesamlphp/modules/material
-    command: bash -c "/data/enable-exampleauth.sh && /data/run.sh"
     depends_on:
       - api-mock.local
     ports:

--- a/development/enable-exampleauth.sh
+++ b/development/enable-exampleauth.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env sh
-
-sed -i 's@^\( *'\''module\.enable'\'' => \[\)@\1\n        '\''exampleauth'\'' => true,@' /data/vendor/simplesamlphp/simplesamlphp/config/config.php

--- a/development/hub/config/extra-config.php
+++ b/development/hub/config/extra-config.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'module.enable' => [
+        'admin' => true,
+    ]
+];

--- a/development/idp-local/config/extra-config.php
+++ b/development/idp-local/config/extra-config.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'module.enable' => [
+        'admin' => true,
+        'exampleauth' => true,
+    ]
+];

--- a/development/idp2-local/config/extra-config.php
+++ b/development/idp2-local/config/extra-config.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'module.enable' => [
+        'admin' => true,
+        'exampleauth' => true,
+    ]
+];

--- a/development/idp3-local/config/extra-config.php
+++ b/development/idp3-local/config/extra-config.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'module.enable' => [
+        'admin' => true,
+        'exampleauth' => false,
+    ]
+];

--- a/development/idp4-local/config/extra-config.php
+++ b/development/idp4-local/config/extra-config.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'module.enable' => [
+        'admin' => true,
+        'exampleauth' => true,
+    ]
+];

--- a/dockerbuild/config/config.php
+++ b/dockerbuild/config/config.php
@@ -655,7 +655,7 @@ $config = [
 
     'module.enable' => [
         'core' => true,
-        'admin' => true,
+        'admin' => false,
         'saml' => true,
         'expirychecker' => true,
         'material' => true,
@@ -1483,4 +1483,13 @@ if ($HUB_MODE) {
     // prefix the 'member' (urn:oid:2.5.4.31) attribute elements with idp.idp_name.
     $config['authproc.idp'][48] = 'sildisco:TagGroup';
     $config['authproc.idp'][49] = 'sildisco:AddIdp2NameId';
+}
+
+$extraConfigFile = '/data/extra-config.php';
+
+if (file_exists($extraConfigFile)) {
+    $extraConfig = include $extraConfigFile;
+    if (is_array($extraConfig)) {
+        $config = array_replace_recursive($config, $extraConfig);
+    }
 }

--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -420,4 +420,15 @@ class MetadataTest extends TestCase
                 ' metadata entry set ... ' . var_export($skippedSps, True));
         }
     }
+
+    public function testAdminModule()
+    {
+        $config = Configuration::getConfig();
+
+        $moduleEnable = $config->getArray('module.enable');
+        var_dump(['module.enable' => $moduleEnable]);
+        $this->assertNotEmpty($moduleEnable);
+
+        $this->assertFalse($moduleEnable['admin'] ?? false);
+    }
 }


### PR DESCRIPTION
[IDP-112](https://support.gtis.sil.org/issue/IDP-112) Consider turning off `core:AdminPassword` authsource

---

### Changed (non-breaking)
- Disabled the admin module as a security precaution. It can be enabled by adding a `extra-config.php` file using an image layer or volume.

Example extra-config.php file:

```php
<?php
return [
    'module.enable' => [
        'admin' => true,
    ]
];
```

Example docker run command:

```
docker run github.io/sil-org/ssp-base -v ${PWD}/extra-config.php:/data/extra-config.php
```

Example Dockerfile:

```Dockerfile
FROM github.io/sil-org/ssp-base

COPY extra-config.php /data/extra-config.php
```