### PR TITLE
remove the core:AdminPassword from the default authsources.php

### DIFF
--- a/dockerbuild/config/authsources.php
+++ b/dockerbuild/config/authsources.php
@@ -3,15 +3,6 @@
 use SimpleSAML\Module\silauth\Auth\Source\config\ConfigManager;
 
 $config = [
-
-    // This is a authentication source which handles admin authentication.
-    'admin' => [
-        // The default is to use core:AdminPassword, but it can be replaced with
-        // any authentication source.
-
-        'core:AdminPassword',
-    ],
-
-    // Use SilAuth
+    // Use the SimpleSAML\Module\silauth\Auth\Source\SilAuth Auth Proc (Authentication Processing Filter)
     'silauth' => ConfigManager::getSspConfig(),
 ];


### PR DESCRIPTION
[IDP-112](https://support.gtis.sil.org/issue/IDP-112) Consider turning off `core:AdminPassword` authsource

---

### Security
- Removed the core:AdminPassword Auth Proc