### PR TITLE
Mark metadata tests Incomplete (not Skipped) when SPs use SkipTests

### DIFF
--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -336,9 +336,11 @@ class MetadataTest extends TestCase
         $spEntries = $metadata->getList('saml20-sp-remote');
 
         $badSps = [];
+        $skippedSps = [];
 
         foreach ($spEntries as $spEntityId => $spEntry) {
             if (!empty($spEntry[self::SkipTestsKey])) {
+                $skippedSps[] = $spEntityId;
                 continue;
             }
 
@@ -351,6 +353,11 @@ class MetadataTest extends TestCase
         $this->assertEmpty($badSps,
             'At least one SP has saml20.sign.response set to false ... ' .
             var_export($badSps, True));
+
+        if ($skippedSps) {
+            fwrite(STDERR, "Skipped saml20.sign.response check for SPs with the '" . self::SkipTestsKey .
+                "' flag: " . var_export($skippedSps, True) . "\n");
+        }
     }
 
     public function testMetadataSignAssertion()
@@ -360,9 +367,11 @@ class MetadataTest extends TestCase
         $spEntries = $metadata->getList('saml20-sp-remote');
 
         $badSps = [];
+        $skippedSps = [];
 
         foreach ($spEntries as $spEntityId => $spEntry) {
             if (!empty($spEntry[self::SkipTestsKey])) {
+                $skippedSps[] = $spEntityId;
                 continue;
             }
 
@@ -375,6 +384,11 @@ class MetadataTest extends TestCase
         $this->assertEmpty($badSps,
             'At least one SP has saml20.sign.assertion set to false ... ' .
             var_export($badSps, True));
+
+        if ($skippedSps) {
+            fwrite(STDERR, "Skipped saml20.sign.assertion check for SPs with the '" . self::SkipTestsKey .
+                "' flag: " . var_export($skippedSps, True) . "\n");
+        }
     }
 
     public function testMetadataEncryption()
@@ -384,9 +398,11 @@ class MetadataTest extends TestCase
         $spEntries = $metadata->getList('saml20-sp-remote');
 
         $badSps = [];
+        $skippedSps = [];
 
         foreach ($spEntries as $spEntityId => $spEntry) {
             if (!empty($spEntry[self::SkipTestsKey])) {
+                $skippedSps[] = $spEntityId;
                 continue;
             }
 
@@ -398,6 +414,11 @@ class MetadataTest extends TestCase
         $this->assertEmpty($badSps,
             'At least one SP does not have assertion.encryption set to True ... ' .
             var_export($badSps, True));
+
+        if ($skippedSps) {
+            fwrite(STDERR, "Skipped assertion.encryption check for SPs with the '" . self::SkipTestsKey .
+                "' flag: " . var_export($skippedSps, True) . "\n");
+        }
     }
 
     public function testAdminModule()

--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -336,11 +336,9 @@ class MetadataTest extends TestCase
         $spEntries = $metadata->getList('saml20-sp-remote');
 
         $badSps = [];
-        $skippedSps = [];
 
         foreach ($spEntries as $spEntityId => $spEntry) {
             if (!empty($spEntry[self::SkipTestsKey])) {
-                $skippedSps[] = $spEntityId;
                 continue;
             }
 
@@ -353,11 +351,6 @@ class MetadataTest extends TestCase
         $this->assertEmpty($badSps,
             'At least one SP has saml20.sign.response set to false ... ' .
             var_export($badSps, True));
-
-        if ($skippedSps) {
-            $this->markTestSkipped('At least one SP had the ' . self::SkipTestsKey .
-                ' metadata entry set ... ' . var_export($skippedSps, True));
-        }
     }
 
     public function testMetadataSignAssertion()
@@ -367,11 +360,9 @@ class MetadataTest extends TestCase
         $spEntries = $metadata->getList('saml20-sp-remote');
 
         $badSps = [];
-        $skippedSps = [];
 
         foreach ($spEntries as $spEntityId => $spEntry) {
             if (!empty($spEntry[self::SkipTestsKey])) {
-                $skippedSps[] = $spEntityId;
                 continue;
             }
 
@@ -384,11 +375,6 @@ class MetadataTest extends TestCase
         $this->assertEmpty($badSps,
             'At least one SP has saml20.sign.assertion set to false ... ' .
             var_export($badSps, True));
-
-        if ($skippedSps) {
-            $this->markTestSkipped('At least one SP had the ' . self::SkipTestsKey .
-                ' metadata entry set ... ' . var_export($skippedSps, True));
-        }
     }
 
     public function testMetadataEncryption()
@@ -398,11 +384,9 @@ class MetadataTest extends TestCase
         $spEntries = $metadata->getList('saml20-sp-remote');
 
         $badSps = [];
-        $skippedSps = [];
 
         foreach ($spEntries as $spEntityId => $spEntry) {
             if (!empty($spEntry[self::SkipTestsKey])) {
-                $skippedSps[] = $spEntityId;
                 continue;
             }
 
@@ -414,11 +398,6 @@ class MetadataTest extends TestCase
         $this->assertEmpty($badSps,
             'At least one SP does not have assertion.encryption set to True ... ' .
             var_export($badSps, True));
-
-        if ($skippedSps) {
-            $this->markTestSkipped('At least one SP had the ' . self::SkipTestsKey .
-                ' metadata entry set ... ' . var_export($skippedSps, True));
-        }
     }
 
     public function testAdminModule()

--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -355,8 +355,10 @@ class MetadataTest extends TestCase
             var_export($badSps, True));
 
         if ($skippedSps) {
-            fwrite(STDERR, "Skipped saml20.sign.response check for SPs with the '" . self::SkipTestsKey .
-                "' flag: " . var_export($skippedSps, True) . "\n");
+            $this->markTestIncomplete(
+                "Did not check saml20.sign.response for SPs with the '" . self::SkipTestsKey .
+                "' flag: " . var_export($skippedSps, True)
+            );
         }
     }
 
@@ -386,8 +388,10 @@ class MetadataTest extends TestCase
             var_export($badSps, True));
 
         if ($skippedSps) {
-            fwrite(STDERR, "Skipped saml20.sign.assertion check for SPs with the '" . self::SkipTestsKey .
-                "' flag: " . var_export($skippedSps, True) . "\n");
+            $this->markTestIncomplete(
+                "Did not check saml20.sign.assertion for SPs with the '" . self::SkipTestsKey .
+                "' flag: " . var_export($skippedSps, True)
+            );
         }
     }
 
@@ -416,8 +420,10 @@ class MetadataTest extends TestCase
             var_export($badSps, True));
 
         if ($skippedSps) {
-            fwrite(STDERR, "Skipped assertion.encryption check for SPs with the '" . self::SkipTestsKey .
-                "' flag: " . var_export($skippedSps, True) . "\n");
+            $this->markTestIncomplete(
+                "Did not check assertion.encryption for SPs with the '" . self::SkipTestsKey .
+                "' flag: " . var_export($skippedSps, True)
+            );
         }
     }
 


### PR DESCRIPTION
[IDP-2034](https://support.gtis.sil.org/issue/IDP-2034) CI tests are skipping more that just ones flagged for 'SkipTests'

---
### Changed (non-breaking)
- `MetadataTest.php` — three tests now call `markTestIncomplete` (yellow `I`) instead of `markTestSkipped` (yellow `S`) when SPs have `SkipTests`; the incomplete message lists the skipped SPs.


---
