### PR TITLE
Add markTestIncomplete coverage to testMetadataCerts for SkipTests SPs

### DIFF
--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -311,10 +311,12 @@ class MetadataTest extends TestCase
         $spEntries = $metadata->getList('saml20-sp-remote');
 
         $badSps = [];
+        $skippedSps = [];
 
         foreach ($spEntries as $spEntityId => $spEntry) {
 
             if (!empty($spEntry[self::SkipTestsKey])) {
+                $skippedSps[] = $spEntityId;
                 continue;
             }
 
@@ -327,6 +329,12 @@ class MetadataTest extends TestCase
             'At least one SP has no certData entry ... ' .
             var_export($badSps, True));
 
+        if ($skippedSps) {
+            $this->markTestIncomplete(
+                "Did not check certData for SPs with the '" . self::SkipTestsKey .
+                "' flag: " . var_export($skippedSps, True)
+            );
+        }
     }
 
     public function testMetadataSignResponse()


### PR DESCRIPTION
[IDP-2034](https://support.gtis.sil.org/issue/IDP-2034) follow-up (testMetadataCerts checklist item)

---

### Changed (non-breaking)
- `tMetadataTest.php` — `testMetadataCerts` now reports skipped `SkipTests` SPs via `markTestIncomplete`, matching the three sibling metadata tests.


---