### PR TITLE
Add password visibility toggle to login page

### DIFF
--- a/modules/material/locales/en/LC_MESSAGES/material.po
+++ b/modules/material/locales/en/LC_MESSAGES/material.po
@@ -98,6 +98,12 @@ msgstr "I need help"
 msgid "{login:profile}"
 msgstr "Manage my profile"
 
+msgid "{login:show_password}"
+msgstr "Show password"
+
+msgid "{login:hide_password}"
+msgstr "Hide password"
+
 msgid "{mfa:title}"
 msgstr "%idpName% 2-Step Verification"
 

--- a/modules/material/locales/es/LC_MESSAGES/material.po
+++ b/modules/material/locales/es/LC_MESSAGES/material.po
@@ -98,6 +98,12 @@ msgstr "necesito ayuda"
 msgid "{login:profile}"
 msgstr "Administrar mi perfil"
 
+msgid "{login:show_password}"
+msgstr "Mostrar contraseña"
+
+msgid "{login:hide_password}"
+msgstr "Ocultar contraseña"
+
 msgid "{mfa:title}"
 msgstr "%idpName% Verificación en 2 pasos"
 

--- a/modules/material/locales/fr/LC_MESSAGES/material.po
+++ b/modules/material/locales/fr/LC_MESSAGES/material.po
@@ -98,6 +98,12 @@ msgstr "j'ai besoin d'aide"
 msgid "{login:profile}"
 msgstr "Gérer mon profil"
 
+msgid "{login:show_password}"
+msgstr "Afficher le mot de passe"
+
+msgid "{login:hide_password}"
+msgstr "Masquer le mot de passe"
+
 msgid "{mfa:title}"
 msgstr "%idpName% Vérification en deux étapes"
 

--- a/modules/material/locales/ko/LC_MESSAGES/material.po
+++ b/modules/material/locales/ko/LC_MESSAGES/material.po
@@ -98,6 +98,12 @@ msgstr "도움이 필요해."
 msgid "{login:profile}"
 msgstr "내 프로필 관리"
 
+msgid "{login:show_password}"
+msgstr "비밀번호 표시"
+
+msgid "{login:hide_password}"
+msgstr "비밀번호 숨기기"
+
 msgid "{mfa:title}"
 msgstr "%idpName% 2 단계 인증"
 

--- a/modules/material/public/styles.2.3.6.css
+++ b/modules/material/public/styles.2.3.6.css
@@ -226,15 +226,15 @@ i.material-icons.mdl-typography--display-4 {
   color: blue;
 }
 
-/* The font-size in the mdl-textfield was overriding the one in caption since 
-   it was defined later in the CSS but the font-size from caption is what was 
+/* The font-size in the mdl-textfield was overriding the one in caption since
+   it was defined later in the CSS but the font-size from caption is what was
    needed here so more specificity required to override it back */
 .mdl-textfield.mdl-typography--caption {
   font-size: 12px
 }
 
 
-/* special case where we want a button for all it's built-in characteristics, 
+/* special case where we want a button for all it's built-in characteristics,
 e.g., primary color, but also want to set the text apart a bit. */
 .mdl-button.mdl-typography--caption {
   text-transform: none;
@@ -267,6 +267,33 @@ a.mdl-button.mdl-typography--body-2, a.mdl-button.mdl-typography--body-2 > i.mat
 
 .mdl-card > .mdl-card__media > img.icon {
   max-width: 24px;
+}
+
+
+/* Password field show/hide toggle */
+.password-field-container {
+  position: relative;
+  width: 100%;
+}
+
+.password-field-container .mdl-textfield__input {
+  padding-right: 40px;
+}
+
+.password-visibility-toggle {
+  position: absolute;
+  right: 0;
+  bottom: 16px;
+  color: rgba(0, 0, 0, 0.54);
+  width: 32px !important;
+  height: 32px !important;
+  min-width: 32px !important;
+  padding: 0 !important;
+}
+
+.password-visibility-toggle .material-icons {
+  font-size: 20px;
+  line-height: 32px;
 }
 
 /* Material icons */

--- a/modules/material/themes/material/silauth/loginuserpass.twig
+++ b/modules/material/themes/material/silauth/loginuserpass.twig
@@ -10,6 +10,18 @@
       event.preventDefault();
     }
 
+    function togglePasswordVisibility() {
+      const input = document.getElementById('password');
+      const btn = document.getElementById('password-visibility-toggle');
+      const icon = btn.querySelector('.material-icons');
+      const isHidden = input.type === 'password';
+
+      input.type = isHidden ? 'text' : 'password';
+      icon.textContent = isHidden ? 'visibility_off' : 'visibility';
+      btn.setAttribute('aria-label', isHidden ? '{{ '{login:hide_password}'|trans|e('js') }}' : '{{ '{login:show_password}'|trans|e('js') }}');
+      btn.setAttribute('aria-pressed', isHidden ? 'true' : 'false');
+    }
+
     function forgotPassword() {
       let url = '{{ password_forgot_url|e('js') }}';
       const username = document.getElementById('username').value;
@@ -97,7 +109,7 @@
             >
           </div>
 
-          <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+          <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label password-field-container">
             <label for="password" class="mdl-textfield__label">
               {{ '{login:label_password}'|trans }}
             </label>
@@ -110,6 +122,17 @@
               {% if username is not empty %} autofocus {% endif %}
               id="password"
             >
+
+            <button
+              type="button"
+              class="mdl-button mdl-js-button mdl-button--icon password-visibility-toggle"
+              onclick="togglePasswordVisibility()"
+              aria-label="{{ '{login:show_password}'|trans|e }}"
+              aria-pressed="false"
+              id="password-visibility-toggle"
+            >
+              <i class="material-icons" aria-hidden="true">visibility</i>
+            </button>
           </div>
         </div>
 


### PR DESCRIPTION
[IDP-2014](https://support.gtis.sil.org/issue/IDP-2014) Request: show/hide option on password field
---

Added show/hide toggle functionality to the password field on the login page to improve user experience and accessibility.

### Added

- Password visibility toggle button (#password-visibility-toggle) with Material Design icons (visibility / visibility_off).
- JavaScript function togglePasswordVisibility() to handle input type switching and manage aria-label/aria-pressed states for accessibility.
- Localization strings ({login:show_password} and {login:hide_password}) for English, Spanish, French, and Korean.
- Dedicated CSS styling for the password field to integrate the toggle within the password field cleanly.